### PR TITLE
added test container (GDEV-657)

### DIFF
--- a/tests/fixtures/mock_api/__init__.py
+++ b/tests/fixtures/mock_api/__init__.py
@@ -12,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-"""Utils for Fixture handling"""
-
-from pathlib import Path
-
-BASE_DIR = Path(__file__).parent.resolve()
+"""Code to start a mock API server in the background of a test."""

--- a/tests/fixtures/mock_api/models.py
+++ b/tests/fixtures/mock_api/models.py
@@ -16,9 +16,27 @@
 
 """Contain models for the mock api calls"""
 
+from enum import Enum
 from typing import List, Literal
 
 from pydantic import BaseModel
+
+
+# fmt: off
+class UploadState(Enum):
+
+    """
+    The current upload state. Can be registered (no information),
+    pending (the user has requested an upload url),
+    uploaded (the user has confirmed the upload),
+    or registered (the file has been registered with the internal-file-registry).
+    """
+
+    REGISTERED = "registered"
+    PENDING = "pending"
+    UPLOADED = "uploaded"
+    COMPLETED = "completed"
+# fmt: on
 
 
 class State(BaseModel):

--- a/tests/fixtures/mock_api/testcontainer.py
+++ b/tests/fixtures/mock_api/testcontainer.py
@@ -1,0 +1,94 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A testcontainer for running the mock app in the background."""
+
+from pathlib import Path
+
+import requests
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.waiting_utils import wait_container_is_ready
+
+APP_MODULE_PATH = Path(__file__).parent.resolve() / "app.py"
+
+
+class MockAPIContainer(DockerContainer):
+    """
+    Test container for RabbitMQ.
+
+    Example
+    -------
+    The example spins up a RabbitMQ broker and uses the `pika` client library
+    (https://pypi.org/project/pika/) establish a connection to the broker.
+    ::
+        from testcontainer.rabbitmq import RabbitMqContainer
+        import pika
+
+        with RabbitMqContainer("rabbitmq:3.9.10") as rabbitmq:
+
+            connection = pika.BlockingConnection(rabbitmq.get_connection_params())
+            channel = connection.channel()
+    """
+
+    def __init__(
+        self,
+        image: str = "ghga/fastapi_essentials:0.73.0",
+        port: int = 8000,
+        download_url: str = "http://test.test/test.fastq",
+    ) -> None:
+        """Initialize the RabbitMQ test container.
+
+        Args:
+            image (str, optional):
+                The docker image from docker hub. Defaults to "rabbitmq:latest".
+            port (int, optional):
+                The port to reach the AMQP API. Defaults to 5672.
+            username (str, optional):
+                Overwrite the default username which is "guest".
+            password (str, optional):
+                Overwrite the default username which is "guest".
+        """
+        super(MockAPIContainer, self).__init__(image=image)
+
+        self._port = port
+
+        self.with_exposed_ports(self._port)
+        self.with_env("MOCK_DOWNLOAD_URL", download_url)
+        self.with_volume_mapping(host=str(APP_MODULE_PATH), container="/app.py")
+        self.with_command(
+            f"python3 -m uvicorn --host 0.0.0.0 --port {self._port} --app-dir / app:app"
+        )
+
+    def get_connection_url(self) -> str:
+        """Returns an HTTP connection URL to the API root."""
+        ip = self.get_container_host_ip()
+        port = self.get_exposed_port(self._port)
+        return f"http://{ip}:{port}"
+
+    @wait_container_is_ready()
+    def readiness_probe(self):
+        """Test if the RabbitMQ broker is ready."""
+        connection_url = self.get_connection_url()
+
+        request = requests.get(f"{connection_url}/ready", timeout=0.5)
+        if request.status_code != 204:
+            raise RuntimeError("Mock API server not ready.")
+
+    def start(self):
+        """Start the test container."""
+        super().start()
+        self.readiness_probe()
+        return self

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -16,13 +16,8 @@
 
 """Tests for the up- and download functions of the cli"""
 
-import asyncio
-from typing import List, Optional
-
 import pytest
-import pytest_asyncio
 import typer
-import uvicorn
 
 from ghga_connector.cli import download, upload
 from ghga_connector.core import (
@@ -31,138 +26,92 @@ from ghga_connector.core import (
     confirm_api_call,
 )
 
-from ..fixtures.mock_api import app
+from ..fixtures.mock_api.testcontainer import MockAPIContainer
 
 
-class UvicornTestServer(uvicorn.Server):
-    """Uvicorn test server
-
-    Usage:
-        @pytest.fixture
-        server = UvicornTestServer()
-        await server.up()
-        yield
-        await server.down()
-    """
-
-    def __init__(self, app=app, host="127.0.0.1", port=8080):
-        """Create a Uvicorn test server
-
-        Args:
-            app (FastAPI, optional): the FastAPI app. Defaults to main.app.
-            host (str, optional): the host ip. Defaults to '127.0.0.1'.
-            port (int, optional): the port. Defaults to PORT.
-        """
-        self._startup_done = asyncio.Event()
-        super().__init__(config=uvicorn.Config(app, host=host, port=port))
-
-    async def startup(self, sockets: Optional[List] = None) -> None:
-        """Override uvicorn startup"""
-        await super().startup(sockets=sockets)
-        self.config.setup_event_loop()
-        self._startup_done.set()
-
-    async def up(self) -> None:
-        """Start up server asynchronously"""
-        self._serve_task = asyncio.create_task(self.serve())
-        await self._startup_done.wait()
-
-    async def down(self) -> None:
-        """Shut down server asynchronously"""
-        self.should_exit = True
-        await self._serve_task
-
-
-@pytest_asyncio.fixture
-async def server():
-    """Start server as test fixture and tear down after test"""
-    server = UvicornTestServer()
-    await server.up()
-    yield
-    await server.down()
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "api_url,file_id,output_dir,expected_exception",
+    "bad_url,file_id,output_dir,expected_exception",
     [
         (
-            "https://no_real_url:8080",
+            True,
             "1",
             "/workspace/example_data/file1.test",
-            typer.Abort(),
+            typer.Abort,
         ),
         (
-            "https://no_real_url:8080",
+            True,
             1,
             "/workspace/example_data/file1.test",
-            typer.Abort(),
+            typer.Abort,
         ),
-        ("https://localhost:8080", "1", "/workspace/example_data/", None),
-        ("https://localhost:8080", "2", "/workspace/example_data/", None),
-        ("https://localhost:8080", "1m", "/workspace/example_data/", None),
-        ("https://localhost:8080", "1", "/this_path/", typer.Abort()),
+        (False, "1", "/workspace/example_data/", None),
+        (False, "2", "/workspace/example_data/", None),
+        (False, "1m", "/workspace/example_data/", None),
+        (False, "1", "/this_path/", typer.Abort),
     ],
 )
-async def test_download(api_url, file_id, output_dir, expected_exception, server):
+def test_download(bad_url, file_id, output_dir, expected_exception):
 
     """Test the download of a file, expects Abort, if the file was not found"""
+    with MockAPIContainer() as api:
+        api_url = "http://bad_url" if bad_url else api.get_connection_url()
 
-    try:
-        download(api_url, file_id, output_dir)
-    except Exception as exception:
-        assert exception == expected_exception
+        try:
+            download(api_url, file_id, output_dir)
+            assert expected_exception is None
+        except Exception as exception:
+            assert isinstance(exception, expected_exception)
 
-    assert expected_exception is None
 
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "api_url,file_id,file_path,expected_exception",
+    "bad_url,file_id,file_path,expected_exception",
     [
         (
-            "https://no_real_url:8080",
+            True,
             "1",
             "/workspace/example_data/file1.test",
-            typer.Abort(),
+            typer.Abort,
         ),
-        ("https://localhost:8080", "1", "/workspace/example_data/file1.test", None),
-        ("https://localhost:8080", "2", "/workspace/example_data/file2.test", None),
+        (False, "1", "/workspace/example_data/file1.test", None),
+        (False, "2", "/workspace/example_data/file2.test", None),
         (
-            "https://localhost:8080",
+            False,
             "1",
             "/this_path/does_not_exist.test",
-            typer.Abort(),
+            typer.Abort,
         ),
     ],
 )
-async def test_upload(api_url, file_id, file_path, expected_exception, server):
+def test_upload(bad_url, file_id, file_path, expected_exception):
 
     """Test the upload of a file, expects Abort, if the file was not found"""
+    with MockAPIContainer() as api:
+        api_url = "http://bad_url" if bad_url else api.get_connection_url()
 
-    try:
-        upload(api_url, file_id, file_path)
-    except Exception as exception:
-        assert exception == expected_exception
-
-    assert expected_exception is None
+        try:
+            upload(api_url, file_id, file_path)
+            assert expected_exception is None
+        except Exception as exception:
+            assert isinstance(exception, expected_exception)
 
 
 @pytest.mark.parametrize(
-    "api_url,file_id,expected_exception",
+    "bad_url,file_id,expected_exception",
     [
-        ("https://localhost:8080", "1", None),
-        ("https://localhost:8080", "2", BadResponseCodeError),
-        ("https://bad_url", "1", RequestFailedError),
+        (False, "1", None),
+        (False, "2", BadResponseCodeError),
+        (True, "1", RequestFailedError),
     ],
 )
-def test_confirm_api_call(api_url, file_id, expected_exception):
+def test_confirm_api_call(bad_url, file_id, expected_exception):
     """
     Test the confirm_api_call function
     """
-    try:
-        confirm_api_call(api_url=api_url, file_id=file_id)
-    except Exception as exception:
-        assert expected_exception == exception
+    with MockAPIContainer() as api:
+        api_url = "http://bad_url" if bad_url else api.get_connection_url()
 
-    assert expected_exception is None
+        try:
+            confirm_api_call(api_url=api_url, file_id=file_id)
+            assert expected_exception is None
+        except Exception as exception:
+            assert isinstance(exception, expected_exception)


### PR DESCRIPTION
Here are my suggestions for the tests container.

Moreover, it fixes the `Abort() == Abort()` issue.

What remains are exceptions like this:
```
        # Make function call to get upload url
        curl = pycurl.Curl()
        data = BytesIO()
        curl.setopt(curl.URL, url)
        curl.setopt(curl.WRITEFUNCTION, data.write)
        curl.setopt(
            curl.HTTPHEADER,
            ["Accept: application/json", "Content-Type: application/json"],
        )
        # GET is the standard, but setting it here explicitely nonetheless
>       curl.setopt(curl.GET, 1)
E       AttributeError: trying to obtain a non-existing attribute: GET
```

But they seem to be related to the ghga-connector package itself not the test framework.