### PR TITLE
file read, file download, and upload URL generators (GDEV-899)

### DIFF
--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -30,10 +30,10 @@ from ghga_connector.core import (
     await_download_url,
     check_url,
     download_file_part,
+    get_part_upload_url,
     patch_multipart_upload,
     start_multipart_upload,
     upload_file_part,
-    upload_part,
 )
 
 DEFAULT_PART_SIZE = 16 * 1024 * 1024
@@ -106,7 +106,7 @@ def upload(  # noqa C901
         raise typer.Abort() from error
 
     try:
-        upload_parts(
+        get_part_upload_urls(
             api_url=api_url,
             upload_id=upload_id,
             part_size=part_size,
@@ -187,7 +187,7 @@ def download(  # pylint: disable=too-many-arguments
     typer.echo(f"File with id '{file_id}' has been successfully downloaded.")
 
 
-def upload_parts(
+def get_part_upload_urls(
     api_url: str,
     upload_id: str,
     part_size: int,
@@ -207,7 +207,7 @@ def upload_parts(
 
         # For 0 retries, we still try the first time
         for retries in range(0, max_retries + 1):
-            presigned_post_url = upload_part(
+            presigned_post_url = get_part_upload_url(
                 api_url=api_url, upload_id=upload_id, part_no=part_no
             )
 

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -30,7 +30,7 @@ from ghga_connector.core import (
     await_download_url,
     check_url,
     download_file_parts,
-    get_part_upload_ulrs,
+    get_part_upload_urls,
     patch_multipart_upload,
     read_file_parts,
     start_multipart_upload,
@@ -192,7 +192,7 @@ def upload_file_parts(
 
     with open(file_path, "rb") as file:
         file_parts = read_file_parts(file, part_size=part_size)
-        upload_urls = get_part_upload_ulrs(api_url=api_url, upload_id=upload_id)
+        upload_urls = get_part_upload_urls(api_url=api_url, upload_id=upload_id)
 
         for part, upload_url in zip(file_parts, upload_urls):
             upload_file_part(presigned_url=upload_url, part=part)

--- a/ghga_connector/core/__init__.py
+++ b/ghga_connector/core/__init__.py
@@ -22,11 +22,11 @@ from .api_calls import (  # noqa: F401
     UploadStatus,
     await_download_url,
     download_api_call,
+    get_part_upload_url,
     get_pending_uploads,
     initiate_multipart_upload,
     patch_multipart_upload,
     start_multipart_upload,
-    upload_part,
 )
 from .exceptions import (  # noqa: F401
     BadResponseCodeError,

--- a/ghga_connector/core/__init__.py
+++ b/ghga_connector/core/__init__.py
@@ -22,7 +22,7 @@ from .api_calls import (  # noqa: F401
     UploadStatus,
     await_download_url,
     download_api_call,
-    get_part_upload_url,
+    get_part_upload_ulrs,
     get_pending_uploads,
     initiate_multipart_upload,
     patch_multipart_upload,
@@ -37,5 +37,9 @@ from .exceptions import (  # noqa: F401
     NoUploadPossibleError,
     RequestFailedError,
 )
-from .file_operations import download_file_part, upload_file_part  # noqa: F401
+from .file_operations import (  # noqa: F401
+    download_file_parts,
+    read_file_parts,
+    upload_file_part,
+)
 from .main import check_url  # noqa: F401

--- a/ghga_connector/core/__init__.py
+++ b/ghga_connector/core/__init__.py
@@ -22,7 +22,7 @@ from .api_calls import (  # noqa: F401
     UploadStatus,
     await_download_url,
     download_api_call,
-    get_part_upload_ulrs,
+    get_part_upload_urls,
     get_pending_uploads,
     initiate_multipart_upload,
     patch_multipart_upload,

--- a/ghga_connector/core/api_calls.py
+++ b/ghga_connector/core/api_calls.py
@@ -171,7 +171,7 @@ def get_part_upload_url(*, api_url: str, upload_id: str, part_no: int):
     return presigned_post
 
 
-def get_part_upload_ulrs(
+def get_part_upload_urls(
     *,
     api_url: str,
     upload_id: str,

--- a/ghga_connector/core/api_calls.py
+++ b/ghga_connector/core/api_calls.py
@@ -22,13 +22,16 @@ import json
 from enum import Enum
 from io import BytesIO
 from time import sleep
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import pycurl
+
+from ghga_connector.core.constants import MAX_PART_NUMBER
 
 from .exceptions import (
     BadResponseCodeError,
     CantCancelUploadError,
+    MaxPartNoExceededError,
     MaxWaitTimeExceeded,
     NoS3AccessMethod,
     NoUploadPossibleError,
@@ -131,9 +134,9 @@ def initiate_multipart_upload(api_url: str, file_id: str) -> Tuple[str, int]:
     return response_body["upload_id"], int(response_body["part_size"])
 
 
-def upload_part(api_url: str, upload_id: str, part_no: int) -> str:
+def get_part_upload_url(*, api_url: str, upload_id: str, part_no: int):
     """
-    Get a presigned url to upload a specific part to S3
+    Get a presigned url to upload a specific part
     """
 
     # build url
@@ -166,6 +169,33 @@ def upload_part(api_url: str, upload_id: str, part_no: int) -> str:
     presigned_post = response_body["presigned_post"]
 
     return presigned_post
+
+
+def get_part_upload_ulrs(
+    *,
+    api_url: str,
+    upload_id: str,
+    from_part: int = 1,
+    get_url_func=get_part_upload_url,
+) -> Iterator[str]:
+    """
+    For a specific mutli-part upload identified by the `upload_id`, it returns an
+    iterator to iterate through file parts and obtain the corresponding upload urls.
+
+    By default it start with the first part but you may also start from a specific part
+    in the middle of the file using the `from_part` argument. This might be useful to
+    resume an interrupted upload process.
+
+    Please note: the upload corresponding to the `upload_id` must have already been
+    initiated.
+
+    `get_url_func` only for testing purposes.
+    """
+
+    for part_no in range(from_part, MAX_PART_NUMBER + 1):
+        yield get_url_func(api_url=api_url, upload_id=upload_id, part_no=part_no)
+
+    raise MaxPartNoExceededError()
 
 
 def patch_multipart_upload(

--- a/ghga_connector/core/constants.py
+++ b/ghga_connector/core/constants.py
@@ -1,0 +1,19 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Constants used throught the core."""
+
+MAX_PART_NUMBER = 10000

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -16,6 +16,8 @@
 
 """Custom Exceptions."""
 
+from ghga_connector.core.constants import MAX_PART_NUMBER
+
 
 class RetryTimeExpectedError(RuntimeError):
     """Thrown, when a request didn't contain a retry time even though it was expected."""
@@ -84,4 +86,18 @@ class MaxRetriesReached(RuntimeError):
 
     def __init__(self, part_no: int):
         message = f"Exceeded maximum retries for part number '{part_no}'."
+        super().__init__(message)
+
+
+class MaxPartNoExceededError(RuntimeError):
+    """
+    Thrown requesting a part no larger that the maximally possible number of parts.
+
+    This exception is a bug.
+    """
+
+    def __init__(
+        self,
+    ):
+        message = f"No more than ({MAX_PART_NUMBER}) file parts can be up-/downloaded."
         super().__init__(message)

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -91,7 +91,7 @@ class MaxRetriesReached(RuntimeError):
 
 class MaxPartNoExceededError(RuntimeError):
     """
-    Thrown requesting a part no larger that the maximally possible number of parts.
+    Thrown requesting a part number larger than the maximally possible number of parts.
 
     This exception is a bug.
     """

--- a/ghga_connector/core/file_operations.py
+++ b/ghga_connector/core/file_operations.py
@@ -18,7 +18,8 @@
 Contains Calls of the Presigned URLs in order to Up- and Download Files
 """
 
-from io import BytesIO
+from io import BufferedReader, BytesIO
+from typing import Iterator
 
 import pycurl
 
@@ -59,6 +60,31 @@ def download_file_part(
         return
 
     raise BadResponseCodeError(url=download_url, response_code=status_code)
+
+
+def read_file_parts(
+    file: BufferedReader, *, part_size: int, from_part: int = 1
+) -> Iterator[bytes]:
+    """
+    Return an iterator to iterate through file parts of the given size (in bytes).
+
+    You may also start from a specific part using the `from_part` (by default set to the
+    first part, so the beginning of the file). This might be useful to resume an
+    interrupted reading process.
+
+    Please note: opening and closing of the file MUST happen outside of this function.
+    """
+
+    initial_offset = part_size * (from_part - 1)
+    file.seek(initial_offset)
+
+    while True:
+        file_part = file.read(part_size)
+
+        if len(file_part) == 0:
+            return
+
+        yield file_part
 
 
 def upload_file_part(

--- a/ghga_connector/core/file_operations.py
+++ b/ghga_connector/core/file_operations.py
@@ -62,7 +62,7 @@ def calc_part_ranges(
     """
     Calculate and return the ranges (start, end) of file parts as a list of tuples.
 
-    By default it start with the first part but you may also start from a specific part
+    By default it starts with the first part but you may also start from a specific part
     in the middle of the file using the `from_part` argument. This might be useful to
     resume an interrupted reading process.
     """

--- a/ghga_connector/core/file_operations.py
+++ b/ghga_connector/core/file_operations.py
@@ -68,9 +68,9 @@ def read_file_parts(
     """
     Return an iterator to iterate through file parts of the given size (in bytes).
 
-    You may also start from a specific part using the `from_part` (by default set to the
-    first part, so the beginning of the file). This might be useful to resume an
-    interrupted reading process.
+    By default it start with the first part but you may also start from a specific part
+    in the middle of the file using the `from_part` argument. This might be useful to
+    resume an interrupted reading process.
 
     Please note: opening and closing of the file MUST happen outside of this function.
     """

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -15,14 +15,13 @@
 
 """Fixtures for testing the storage DAO"""
 
-from typing import List, Iterator
 from dataclasses import dataclass
+from typing import List
 
-import pytest
 from ghga_service_chassis_lib.object_storage_dao_testing import ObjectFixture
 from ghga_service_chassis_lib.s3_testing import (
-    s3_fixture_factory,
     S3Fixture,
+    s3_fixture_factory,
     upload_file,
 )
 from ghga_service_chassis_lib.utils import big_temp_file

--- a/tests/integration/test_file_operations.py
+++ b/tests/integration/test_file_operations.py
@@ -1,0 +1,55 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test file operations"""
+
+
+import pytest
+from ghga_service_chassis_lib.utils import big_temp_file
+
+from ghga_connector.core.file_operations import download_file_part
+
+from tests.fixtures.s3 import s3_fixture, S3Fixture, get_big_s3_object
+
+
+@pytest.mark.parametrize(
+    "part_start, part_end, file_size",
+    [
+        (0, 20 * 1024 * 1024 - 1, 20 * 1024 * 1024),  # download full file as one part
+        (  # download intermediate part:
+            5 * 1024 * 1024,
+            10 * 1024 * 1024 - 1,
+            20 * 1024 * 1024,
+        ),
+    ],
+)
+def test_download_file_part(
+    part_start: int, part_end: int, file_size: int, s3_fixture: S3Fixture
+):
+    """Test the `download_file_part` function."""
+    # prepare state and the expected result:
+    big_object = get_big_s3_object(s3_fixture, object_size=file_size)
+    download_url = s3_fixture.storage.get_object_download_url(
+        object_id=big_object.object_id, bucket_id=big_object.bucket_id
+    )
+    expected_bytes = big_object.content[part_start : part_end + 1]
+
+    # donwload file part wiht dedicated function:
+    obtained_bytes = download_file_part(
+        download_url=download_url, part_start=part_start, part_end=part_end
+    )
+
+    assert expected_bytes == obtained_bytes

--- a/tests/integration/test_file_operations.py
+++ b/tests/integration/test_file_operations.py
@@ -88,7 +88,7 @@ def test_download_file_parts(
     if from_part is not None:
         kwargs["from_part"] = from_part
 
-    # donwload file parst with dedicated function:
+    # donwload file parts with dedicated function:
     obtained_bytes = bytes()
     for part in download_file_parts(**kwargs):
         obtained_bytes += part

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -29,7 +29,7 @@ from ghga_connector.core import (
     get_pending_uploads,
     patch_multipart_upload,
 )
-from ghga_connector.core.api_calls import get_part_upload_ulrs
+from ghga_connector.core.api_calls import get_part_upload_urls
 from ghga_connector.core.exceptions import MaxPartNoExceededError
 
 from ..fixtures.mock_api.testcontainer import MockAPIContainer
@@ -117,7 +117,7 @@ def test_get_part_upload_ulrs(
     exception: Optional[Exception],
 ):
     """
-    Test the `get_part_upload_ulrs` generator for iterating through signed part urls
+    Test the `get_part_upload_urls` generator for iterating through signed part urls
     """
     upload_id = "example-upload"
     api_url = "http://my-api.example"
@@ -135,7 +135,7 @@ def test_get_part_upload_ulrs(
     }
     if from_part is not None:
         kwargs["from_part"] = from_part
-    part_upload_urls = get_part_upload_ulrs(**kwargs)  # type: ignore
+    part_upload_urls = get_part_upload_urls(**kwargs)  # type: ignore
 
     with (pytest.raises(exception) if exception else nullcontext()):
         for idx, signed_url in enumerate(part_upload_urls):

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -121,7 +121,7 @@ def test_get_part_upload_ulrs(
     """
     upload_id = "example-upload"
     api_url = "http://my-api.example"
-    from_part_ = from_part if from_part else 1
+    from_part_ = 1 if from_part is None else from_part
 
     # mock the function to get a specific part upload url:
     static_signed_url = "http://my-signed-url.example/97982jsdf7823j"
@@ -133,7 +133,7 @@ def test_get_part_upload_ulrs(
         "upload_id": upload_id,
         "get_url_func": get_url_func,
     }
-    if from_part:
+    if from_part is not None:
         kwargs["from_part"] = from_part
     part_upload_urls = get_part_upload_ulrs(**kwargs)  # type: ignore
 

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -16,6 +16,9 @@
 
 """Tests for API Calls"""
 
+from contextlib import nullcontext
+from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 
@@ -26,6 +29,8 @@ from ghga_connector.core import (
     get_pending_uploads,
     patch_multipart_upload,
 )
+from ghga_connector.core.api_calls import get_part_upload_ulrs
+from ghga_connector.core.exceptions import MaxPartNoExceededError
 
 from ..fixtures.mock_api.testcontainer import MockAPIContainer
 
@@ -96,3 +101,50 @@ def test_patch_multipart_upload(
             assert expected_exception is None
         except Exception as exception:
             assert isinstance(exception, expected_exception)
+
+
+@pytest.mark.parametrize(
+    "from_part, end_part, exception",
+    [
+        (None, 10, None),
+        (2, 10, None),
+        (9999, 10001, MaxPartNoExceededError),
+    ],
+)
+def test_get_part_upload_ulrs(
+    from_part: Optional[int],
+    end_part: int,
+    exception: Optional[Exception],
+):
+    """
+    Test the `get_part_upload_ulrs` generator for iterating through signed part urls
+    """
+    upload_id = "example-upload"
+    api_url = "http://my-api.example"
+    from_part_ = from_part if from_part else 1
+
+    # mock the function to get a specific part upload url:
+    static_signed_url = "http://my-signed-url.example/97982jsdf7823j"
+    get_url_func = Mock(return_value=static_signed_url)
+
+    # create the iterator:
+    kwargs = {
+        "api_url": api_url,
+        "upload_id": upload_id,
+        "get_url_func": get_url_func,
+    }
+    if from_part:
+        kwargs["from_part"] = from_part
+    part_upload_urls = get_part_upload_ulrs(**kwargs)  # type: ignore
+
+    with (pytest.raises(exception) if exception else nullcontext()):
+        for idx, signed_url in enumerate(part_upload_urls):
+            assert static_signed_url == signed_url
+
+            part_no = idx + from_part_
+            get_url_func.assert_called_with(
+                api_url=api_url, upload_id=upload_id, part_no=part_no
+            )
+
+            if part_no >= end_part:
+                break

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -16,15 +16,9 @@
 
 """Tests for the core functions of the cli"""
 
-import os
-from filecmp import cmp
-
 import pytest
 
-from ghga_connector.core import check_url, download_file_part
-
-from ..fixtures import s3_fixture  # noqa: F401
-from ..fixtures import state
+from ghga_connector.core import check_url
 
 
 @pytest.mark.parametrize(
@@ -38,32 +32,3 @@ def test_check_url(api_url, wait_time, expected_response):
     """
     response = check_url(api_url, wait_time)
     assert response == expected_response
-
-
-def test_download_file(
-    s3_fixture,  # noqa F811
-    tmp_path,
-):
-    """
-    Test the download_file function
-    """
-
-    file_path = tmp_path / "file.test"
-
-    downloadable_file = state.FILES["file_downloadable"]
-    download_url = s3_fixture.storage.get_object_download_url(
-        bucket_id=downloadable_file.grouping_label,
-        object_id=downloadable_file.file_id,
-        expires_after=3600,
-    )
-
-    # Try to download the whole test file in one part. Should be fairly small.
-    download_file_part(
-        download_url=download_url,
-        output_file_path=file_path,
-        part_offset=0,
-        part_size=os.path.getsize(downloadable_file.file_path),
-        file_size=os.path.getsize(downloadable_file.file_path),
-    )
-
-    assert cmp(file_path, downloadable_file.file_path)

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -21,11 +21,7 @@ from typing import Optional
 import pytest
 from ghga_service_chassis_lib.utils import big_temp_file
 
-from ghga_connector.core.file_operations import (
-    read_file_parts,
-    download_file_parts,
-    calc_part_ranges,
-)
+from ghga_connector.core.file_operations import read_file_parts
 
 
 @pytest.mark.parametrize("from_part", (None, 3))
@@ -37,7 +33,7 @@ def test_read_file_parts(from_part: Optional[int]):
     with big_temp_file(file_size) as file:
 
         # Get the expected content:
-        initial_offset = part_size * (from_part - 1) if from_part else 0
+        initial_offset = 0 if from_part is None else part_size * (from_part - 1)
         file.seek(initial_offset)
         expected_content = file.read()
         file.seek(0)
@@ -45,9 +41,9 @@ def test_read_file_parts(from_part: Optional[int]):
         # read the file in parts:
         obtained_content = bytes()
         file_parts = (
-            read_file_parts(file, part_size=part_size, from_part=from_part)
-            if from_part
-            else read_file_parts(file, part_size=part_size)
+            read_file_parts(file, part_size=part_size)
+            if from_part is None
+            else read_file_parts(file, part_size=part_size, from_part=from_part)
         )
 
         for part in file_parts:

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -1,0 +1,52 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test file operations"""
+
+from typing import Optional
+
+import pytest
+from ghga_service_chassis_lib.utils import big_temp_file
+
+from ghga_connector.core.file_operations import read_file_parts
+
+
+@pytest.mark.parametrize("from_part", (None, 3))
+def test_read_file_parts(from_part: Optional[int]):
+    """Test reading a full file with the `read_file_parts` function."""
+    file_size = 20 * 1024 * 1024
+    part_size = 5 * 1024 * 1024
+
+    with big_temp_file(file_size) as file:
+
+        # Get the expected content:
+        initial_offset = part_size * (from_part - 1) if from_part else 0
+        file.seek(initial_offset)
+        expected_content = file.read()
+        file.seek(0)
+
+        # read the file in parts:
+        obtained_content = bytes()
+        file_parts = (
+            read_file_parts(file, part_size=part_size, from_part=from_part)
+            if from_part
+            else read_file_parts(file, part_size=part_size)
+        )
+
+        for part in file_parts:
+            obtained_content += part
+
+        assert expected_content == obtained_content

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -21,7 +21,11 @@ from typing import Optional
 import pytest
 from ghga_service_chassis_lib.utils import big_temp_file
 
-from ghga_connector.core.file_operations import read_file_parts
+from ghga_connector.core.file_operations import (
+    read_file_parts,
+    download_file_parts,
+    calc_part_ranges,
+)
 
 
 @pytest.mark.parametrize("from_part", (None, 3))


### PR DESCRIPTION
Description for squash and merge:
```
Adds following generator:
- `read_file_parts` returns an iterator to read file parts from disk
- `download_file_parts` returns an iterator to download file parts 
   using a signed download URL
- `get_part_upload_url` returns an iterator to get part-specific
   download URLs from the UCS

Added some basic tests, more to follow.
Temporarily removed the retry logic.
```