### PR TITLE
Feature/retry logic decorator gdev 901

### DIFF
--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -41,10 +41,10 @@ from ghga_connector.core import (
     start_multipart_upload,
     upload_file_part,
 )
+from ghga_connector.core.constants import MAX_RETRIES
 from ghga_connector.core.decorators import Retry
 
 DEFAULT_PART_SIZE = 16 * 1024 * 1024
-MAX_RETRIES = 3
 
 
 class DirectoryDoesNotExist(RuntimeError, GHGAConnectorException):
@@ -199,7 +199,7 @@ def download(  # pylint: disable=too-many-arguments, disable=unused-argument
         default=MAX_RETRIES,
         help="Number of times to retry failed part downloads",
         callback=Retry.set_retries,
-    ),  # pylint: disable=unused-argument
+    ),
 ):
     """
     Command to download a file

--- a/ghga_connector/core/api_calls.py
+++ b/ghga_connector/core/api_calls.py
@@ -26,6 +26,7 @@ from typing import Dict, Iterator, Tuple, Union
 import requests
 
 from ghga_connector.core.constants import MAX_PART_NUMBER
+from ghga_connector.core.decorators import Retry
 from ghga_connector.core.message_display import AbstractMessageDisplay
 
 from .exceptions import (
@@ -62,6 +63,7 @@ class UploadStatus(str, Enum):
     UPLOADED = "uploaded"
 
 
+@Retry
 def initiate_multipart_upload(api_url: str, file_id: str) -> Tuple[str, int]:
     """
     Perform a RESTful API call to initiate a multipart upload
@@ -93,6 +95,7 @@ def initiate_multipart_upload(api_url: str, file_id: str) -> Tuple[str, int]:
     return response_body["upload_id"], int(response_body["part_size"])
 
 
+@Retry
 def get_part_upload_url(*, api_url: str, upload_id: str, part_no: int):
     """
     Get a presigned url to upload a specific part
@@ -149,6 +152,7 @@ def get_part_upload_urls(
     raise MaxPartNoExceededError()
 
 
+@Retry
 def patch_multipart_upload(
     api_url: str, upload_id: str, upload_status: UploadStatus
 ) -> None:
@@ -210,6 +214,7 @@ def get_upload_info(
     return response.json()
 
 
+@Retry
 def get_file_metadata(api_url: str, file_id: str) -> Dict:
     """
     Get all file metadata

--- a/ghga_connector/core/constants.py
+++ b/ghga_connector/core/constants.py
@@ -17,3 +17,4 @@
 """Constants used throught the core."""
 
 MAX_PART_NUMBER = 10000
+MAX_RETRIES = 3

--- a/ghga_connector/core/decorators.py
+++ b/ghga_connector/core/decorators.py
@@ -1,0 +1,54 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Eeusable decorators"""
+from typing import Any, Callable
+
+from ghga_connector.core.exceptions import GHGAConnectorException, MaxRetriesReached
+
+MAX_RETRIES = 3
+
+
+class Retry:
+    """Class decorator providing common retry logic"""
+
+    num_retries: int = MAX_RETRIES
+
+    def __init__(self, func: Callable) -> None:
+        self.func = func
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Callable:
+        def retry():
+            # try calling decorated function at least once
+            for i in range(Retry.num_retries + 1):
+                try:
+                    func = self.func(*args, **kwargs)
+                    return func
+                except GHGAConnectorException as exception:
+                    print(
+                        f"""Attempt {i+1} for {self.func.__name__}
+                        failed due to: '{exception.__cause__}'"""
+                    )
+            raise MaxRetriesReached(self.func.__name__)
+
+        return retry()
+
+    @classmethod
+    def set_retries(cls, num_retries: int) -> None:
+        """
+        Use this method when setting the number of retries from commandline options by callback
+        """
+        cls.num_retries = num_retries

--- a/ghga_connector/core/decorators.py
+++ b/ghga_connector/core/decorators.py
@@ -50,7 +50,7 @@ class Retry:
                 except Exception as exception:  # pylint: disable=broad-except
                     if isinstance(exception, FatalError):
                         raise exception
-                    exception_causes.append(exception.__cause__)
+                    exception_causes.append(repr(exception))
                     # Use exponential backoff for retries
                     backoff_factor = 0.5
                     exponential_backoff = backoff_factor * (2 ** (i))

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -32,7 +32,7 @@ class FatalError(BaseException):
     """
 
 
-class RetryTimeExpectedError(RuntimeError, GHGAConnectorException):
+class RetryTimeExpectedError(RuntimeError, GHGAConnectorException, FatalError):
     """Thrown, when a request didn't contain a retry time even though it was expected."""
 
     def __init__(self, url: str):
@@ -50,7 +50,7 @@ class RequestFailedError(RuntimeError):
         super().__init__(message)
 
 
-class NoS3AccessMethod(RuntimeError, GHGAConnectorException):
+class NoS3AccessMethod(RuntimeError, GHGAConnectorException, FatalError):
     """Thrown, when a request returns the desired response code, but no S3 Access Method"""
 
     def __init__(self, url: str):
@@ -58,7 +58,7 @@ class NoS3AccessMethod(RuntimeError, GHGAConnectorException):
         super().__init__(message)
 
 
-class FileNotRegisteredError(RuntimeError, GHGAConnectorException):
+class FileNotRegisteredError(RuntimeError, GHGAConnectorException, FatalError):
     """Thrown, when a request for a file returns a 404 error."""
 
     def __init__(self, file_id: str):
@@ -69,7 +69,7 @@ class FileNotRegisteredError(RuntimeError, GHGAConnectorException):
         super().__init__(message)
 
 
-class UploadNotRegisteredError(RuntimeError, GHGAConnectorException):
+class UploadNotRegisteredError(RuntimeError, GHGAConnectorException, FatalError):
     """Thrown, when a request for a multipart upload returns a 404 error."""
 
     def __init__(self, upload_id: str):
@@ -80,7 +80,7 @@ class UploadNotRegisteredError(RuntimeError, GHGAConnectorException):
         super().__init__(message)
 
 
-class BadResponseCodeError(RuntimeError):
+class BadResponseCodeError(RuntimeError, FatalError):
     """Thrown, when a request returns an unexpected response code (e.g. 500)"""
 
     def __init__(self, url: str, response_code: int):
@@ -89,7 +89,7 @@ class BadResponseCodeError(RuntimeError):
         super().__init__(message)
 
 
-class NoUploadPossibleError(RuntimeError, GHGAConnectorException):
+class NoUploadPossibleError(RuntimeError, GHGAConnectorException, FatalError):
     """Thrown, when a multipart upload currently can't be started (response code 400)"""
 
     def __init__(self, file_id: str):
@@ -100,7 +100,7 @@ class NoUploadPossibleError(RuntimeError, GHGAConnectorException):
         super().__init__(message)
 
 
-class UserHasNoUploadAccess(RuntimeError, GHGAConnectorException):
+class UserHasNoUploadAccess(RuntimeError, GHGAConnectorException, FatalError):
     """
     Thrown when a user does not have the credentials to get or change
     details of an ongoing upload with a specific upload id
@@ -115,7 +115,7 @@ class UserHasNoUploadAccess(RuntimeError, GHGAConnectorException):
         super().__init__(message)
 
 
-class UserHasNoFileAccess(RuntimeError, GHGAConnectorException):
+class UserHasNoFileAccess(RuntimeError, GHGAConnectorException, FatalError):
     """
     Thrown when a user does not have the credentials for
     a specific file id (response code 403)
@@ -129,7 +129,7 @@ class UserHasNoFileAccess(RuntimeError, GHGAConnectorException):
         super().__init__(message)
 
 
-class CantChangeUploadStatus(RuntimeError, GHGAConnectorException):
+class CantChangeUploadStatus(RuntimeError, GHGAConnectorException, FatalError):
     """
     Thrown when the upload status of a file can't be set to the requested status
     (response code 400)

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -155,7 +155,7 @@ class MaxRetriesReached(RuntimeError, GHGAConnectorException):
         # keep track for testing purposes
         self.num_causes = len(causes)
         message = (
-            f"Exceeded maximum retries for '{func_name}'. Exceptions encountered:\n"
+            f"Exceeded maximum retries for '{func_name}'.\nExceptions encountered:\n"
         )
         for i, cause in enumerate(causes):
             message += f"{i+1}: {cause}\n"

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -19,14 +19,14 @@
 from ghga_connector.core.constants import MAX_PART_NUMBER
 
 
-class GHGAConnectorException(BaseException):
+class GHGAConnectorException(Exception):
     """
     Base Exception for all custom-thrown exceptions.
     Indicates expected behaviour such as user error or unstable connections
     """
 
 
-class FatalError(BaseException):
+class FatalError(Exception):
     """
     Base Exception for all exceptions that should not trigger retry logic
     """
@@ -151,8 +151,14 @@ class MaxWaitTimeExceeded(RuntimeError, GHGAConnectorException):
 class MaxRetriesReached(RuntimeError, GHGAConnectorException):
     """Thrown, when the specified number of retries has been exceeded."""
 
-    def __init__(self, func_name: str):
-        message = f"Exceeded maximum retries for '{func_name}'."
+    def __init__(self, func_name: str, causes: list):
+        # keep track for testing purposes
+        self.num_causes = len(causes)
+        message = (
+            f"Exceeded maximum retries for '{func_name}'\nExceptions encountered:\n"
+        )
+        for i, cause in enumerate(causes):
+            message += f"{i+1}: {cause}"
         super().__init__(message)
 
 

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -144,8 +144,8 @@ class MaxWaitTimeExceeded(RuntimeError, GHGAConnectorException):
 class MaxRetriesReached(RuntimeError, GHGAConnectorException):
     """Thrown, when the specified number of retries has been exceeded."""
 
-    def __init__(self, part_no: int):
-        message = f"Exceeded maximum retries for part number '{part_no}'."
+    def __init__(self, func_name: str):
+        message = f"Exceeded maximum retries for '{func_name}'."
         super().__init__(message)
 
 

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -26,6 +26,12 @@ class GHGAConnectorException(BaseException):
     """
 
 
+class FatalError(BaseException):
+    """
+    Base Exception for all exceptions that should not trigger retry logic
+    """
+
+
 class RetryTimeExpectedError(RuntimeError, GHGAConnectorException):
     """Thrown, when a request didn't contain a retry time even though it was expected."""
 
@@ -78,6 +84,7 @@ class BadResponseCodeError(RuntimeError):
     """Thrown, when a request returns an unexpected response code (e.g. 500)"""
 
     def __init__(self, url: str, response_code: int):
+        self.response_code = response_code
         message = f"The request to {url} failed with response code {response_code}"
         super().__init__(message)
 

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -155,10 +155,10 @@ class MaxRetriesReached(RuntimeError, GHGAConnectorException):
         # keep track for testing purposes
         self.num_causes = len(causes)
         message = (
-            f"Exceeded maximum retries for '{func_name}'\nExceptions encountered:\n"
+            f"Exceeded maximum retries for '{func_name}'. Exceptions encountered:\n"
         )
         for i, cause in enumerate(causes):
-            message += f"{i+1}: {cause}"
+            message += f"{i+1}: {cause}\n"
         super().__init__(message)
 
 

--- a/ghga_connector/core/file_operations.py
+++ b/ghga_connector/core/file_operations.py
@@ -24,9 +24,12 @@ from typing import Iterator, Sequence
 
 import pycurl
 
+from ghga_connector.core.decorators import Retry
+
 from .exceptions import BadResponseCodeError, RequestFailedError
 
 
+@Retry
 def download_content_range(
     *,
     download_url: str,
@@ -132,6 +135,7 @@ def read_file_parts(
         yield file_part
 
 
+@Retry
 def upload_file_part(*, presigned_url: str, part: bytes) -> None:
     """Upload File"""
 

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -24,13 +24,12 @@ import pytest
 
 from ghga_connector.core import (
     CantChangeUploadStatus,
-    RequestFailedError,
     UploadNotRegisteredError,
     UploadStatus,
     patch_multipart_upload,
 )
 from ghga_connector.core.api_calls import get_part_upload_urls
-from ghga_connector.core.exceptions import MaxPartNoExceededError
+from ghga_connector.core.exceptions import MaxPartNoExceededError, MaxRetriesReached
 
 from ..fixtures.mock_api.testcontainer import MockAPIContainer
 
@@ -43,7 +42,7 @@ from ..fixtures.mock_api.testcontainer import MockAPIContainer
         (False, "pending", UploadStatus.CANCELLED, CantChangeUploadStatus),
         (False, "uploadable", UploadStatus.UPLOADED, CantChangeUploadStatus),
         (False, "not_uploadable", UploadStatus.UPLOADED, UploadNotRegisteredError),
-        (True, "uploaded", UploadStatus.UPLOADED, RequestFailedError),
+        (True, "uploaded", UploadStatus.UPLOADED, MaxRetriesReached),
     ],
 )
 def test_patch_multipart_upload(


### PR DESCRIPTION
Added `Retry` class decorator.
Retry keeps `num_retries` as state, `@cli.command` can set another value than the default `MAX_RETRIES` using the classmethod `Retry.set_retries` as callback.
Pylint complains as it has no knowledge that the argument is being passed to the callback,
Modifying the class variable directly does not work, as the type is infered to be "ArgumentInfo", lacking the knowledge about what typer does to the Argument.

Changed GHGAConnectorException to derive from `Exception` instead of `BaseException`, as per Python docs.
Added `FatalError` for exceptions that should not trigger a retry.
Modfied other expections accordingly

Added a unit test for some sanity checks for the class decorator.