### PR TITLE
remove global config params from CLI (GDEV-1020)

### DIFF
--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -16,10 +16,14 @@
 
 """ CLI-specific wrappers around core functions."""
 
+from pathlib import Path
 
 import typer
 
 from ghga_connector import core
+from ghga_connector.config import Config
+
+config = Config()  # will be patched for testing
 
 
 class CLIMessageDisplay(core.AbstractMessageDisplay):
@@ -48,49 +52,31 @@ class CLIMessageDisplay(core.AbstractMessageDisplay):
 
 
 cli = typer.Typer()
-message_display: core.AbstractMessageDisplay = CLIMessageDisplay()
 
 
 @cli.command()
 def upload(  # noqa C901
-    api_url: str = typer.Option(..., help="Url to the upload contoller"),
     file_id: str = typer.Option(..., help="The id if the file to upload"),
-    file_path: str = typer.Option(..., help="The path to the file to upload"),
-    max_retries: int = typer.Argument(
-        default=core.MAX_RETRIES,
-        help="Number of times to retry failed part uploads",
-    ),
+    file_path: Path = typer.Option(..., help="The path to the file to upload"),
 ):
     """
     Command to upload a file
     """
 
     core.upload(
-        api_url=api_url,
+        api_url=config.upload_api,
         file_id=file_id,
         file_path=file_path,
-        max_retries=max_retries,
-        message_display=message_display,
+        max_retries=config.max_retries,
+        message_display=CLIMessageDisplay(),
     )
 
 
 @cli.command()
 def download(  # pylint: disable=too-many-arguments
-    api_url: str = typer.Option(..., help="Url to the DRS3"),
     file_id: str = typer.Option(..., help="The id if the file to upload"),
-    output_dir: str = typer.Option(
+    output_dir: Path = typer.Option(
         ..., help="The directory to put the downloaded file"
-    ),
-    max_wait_time: int = typer.Argument(
-        60,
-        help="Maximal time in seconds to wait before quitting without a download.",
-    ),
-    part_size: int = typer.Argument(
-        core.DEFAULT_PART_SIZE, help="Part size of the downloaded chunks."
-    ),
-    max_retries: int = typer.Argument(
-        default=core.MAX_RETRIES,
-        help="Number of times to retry failed part downloads",
     ),
 ):
     """
@@ -98,11 +84,11 @@ def download(  # pylint: disable=too-many-arguments
     """
 
     core.download(
-        api_url=api_url,
+        api_url=config.download_api,
         file_id=file_id,
         output_dir=output_dir,
-        max_wait_time=max_wait_time,
-        part_size=part_size,
-        max_retries=max_retries,
-        message_display=message_display,
+        max_wait_time=config.max_wait_time,
+        part_size=config.part_size,
+        max_retries=config.max_retries,
+        message_display=CLIMessageDisplay(),
     )

--- a/ghga_connector/config.py
+++ b/ghga_connector/config.py
@@ -1,0 +1,49 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Global Config Parameters"""
+
+from ghga_service_chassis_lib.config import config_from_yaml
+from pydantic import BaseSettings, Field
+
+from ghga_connector import core
+
+
+@config_from_yaml(prefix="ghga-connector")
+class Config(BaseSettings):
+    "Global Config Parameters"
+
+    upload_api: str = Field(
+        "https://hd-dev.ghga-dev.de/ucs",
+        description="URL to the root of the upload controller API.",
+    )
+    download_api: str = Field(
+        "https://hd-dev.ghga-dev.de/drs3/ga4gh/drs/v1",
+        description="URL to the root of the DRS-compatible API used for download.",
+    )
+
+    max_retries: int = Field(
+        core.MAX_RETRIES, description="Number of times to retry failed API calls."
+    )
+    max_wait_time: int = Field(
+        core.MAX_WAIT_TIME,
+        description=(
+            "Maximal time in seconds to wait before quitting without a download."
+        ),
+    )
+    part_size: int = Field(
+        core.DEFAULT_PART_SIZE, description="The part size to use for download."
+    )

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -16,6 +16,8 @@
 
 """Custom Exceptions."""
 
+from pathlib import Path
+
 from ghga_connector.core.constants import MAX_PART_NUMBER
 
 
@@ -74,7 +76,7 @@ class CollectiveError(RuntimeError, KnownError):
 class DirectoryDoesNotExist(RuntimeError, KnownError):
     """Thrown, when the specified directory does not exist."""
 
-    def __init__(self, output_dir: str):
+    def __init__(self, output_dir: Path):
         message = f"The directory {output_dir} does not exist."
         super().__init__(message)
 
@@ -90,7 +92,7 @@ class FileAlreadyExistsError(RuntimeError, KnownError):
 class FileDoesNotExistError(RuntimeError, KnownError):
     """Thrown, when the specified file already exists."""
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: Path):
         message = f"The file {file_path} does not exist."
         super().__init__(message)
 

--- a/ghga_connector/core/main.py
+++ b/ghga_connector/core/main.py
@@ -17,6 +17,7 @@
 """Main domain logic."""
 
 import os
+from pathlib import Path
 
 import requests
 
@@ -47,6 +48,7 @@ from .retry import WithRetry
 
 # define core-wide constants
 MAX_RETRIES = 3
+MAX_WAIT_TIME = 60
 DEFAULT_PART_SIZE = 16 * 1024 * 1024
 
 
@@ -65,7 +67,7 @@ def check_url(api_url, wait_time=1000) -> bool:
 def upload(  # noqa C901, pylint: disable=too-many-statements
     api_url: str,
     file_id: str,
-    file_path: str,
+    file_path: Path,
     message_display: AbstractMessageDisplay,
     max_retries: int = MAX_RETRIES,
 ) -> None:
@@ -148,7 +150,7 @@ def upload_file_parts(
     api_url: str,
     upload_id: str,
     part_size: int,
-    file_path: str,
+    file_path: Path,
 ) -> None:
     """
     Uploads a file using a specific upload id via uploading all its parts.
@@ -165,10 +167,10 @@ def upload_file_parts(
 def download(  # pylint: disable=too-many-arguments
     api_url: str,
     file_id: str,
-    output_dir: str,
+    output_dir: Path,
     part_size: int,
     message_display: AbstractMessageDisplay,
-    max_wait_time: int = 60,
+    max_wait_time: int = MAX_WAIT_TIME,
     max_retries: int = MAX_RETRIES,
 ) -> None:
     """

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -12,18 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
-"""
-This sub-package contains the main business functionality of this service.
-It should not contain any service API-related code.
-"""
+"""Config utilies."""
 
-from . import exceptions  # noqa: F401
-from .main import (  # noqa: F401
-    DEFAULT_PART_SIZE,
-    MAX_RETRIES,
-    MAX_WAIT_TIME,
-    download,
-    upload,
+from ghga_connector import core
+from ghga_connector.config import Config
+
+DEFAULT_TEST_CONFIG = Config(
+    upload_api="http:/example.org/upload",
+    download_api="http:/example.org/download",
+    max_retries=0,
+    max_wait_time=2,
+    part_size=core.DEFAULT_PART_SIZE,
 )
-from .message_display import AbstractMessageDisplay, MessageColors  # noqa: F401
+
+
+def get_test_config(**kwargs):
+    """Get test config params with the defaults being overwritting by the parameter
+    passed as kwargs.
+    """
+
+    return DEFAULT_TEST_CONFIG.copy(update=kwargs)


### PR DESCRIPTION
Remove following parameters from the CLI:
- download_api
- upload_api
- max_retries
- max_wait_time
- part_size

Instead, they are now defined in a Config class that uses
the config injection functionality from the
ghga-service-chassis-lib.