### PR TITLE
Changed exponential backoff to larger timeouts

### DIFF
--- a/ghga_connector/core/retry.py
+++ b/ghga_connector/core/retry.py
@@ -57,8 +57,7 @@ class WithRetry:
                         raise error
                     error_causes.append(error)
                     # Use exponential backoff for retries
-                    backoff_factor = 0.5
-                    exponential_backoff = backoff_factor * (2 ** (i))
+                    exponential_backoff = 5**i
                     time.sleep(exponential_backoff)
             raise exceptions.MaxRetriesReachedError(
                 func_name=self._func.__name__, causes=error_causes


### PR DESCRIPTION
Exponential backoff now follows formula `5**i` instead of `0.5*2**i`.
I.e. the first four factors are 1, 5, 25 and 125 seconds now.