### PR TITLE
Split chassis-lib s3 dep

### DIFF
--- a/ghga_connector/__init__.py
+++ b/ghga_connector/__init__.py
@@ -17,4 +17,4 @@
 CLI - Client to perform up- and download operations to and from a local ghga instance
 """
 
-__version__ = "0.2.11"
+__version__ = "0.2.12"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@
 testcontainers==3.4.1
 fastapi==0.89.1
 uvicorn[standard]==0.20.0
+ghga-service-chassis-lib[s3]==0.17.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     httpyexpect==0.2.4
     typer==0.7.0
     crypt4gh==1.6
-    ghga-service-chassis-lib[s3]==0.17.7
+    ghga-service-chassis-lib==0.17.7
 
 python_requires = >= 3.9.10
 


### PR DESCRIPTION
Needed due to hexkit[s3] dependency collision in testbed