### PR TITLE
Remove chassis lib

### DIFF
--- a/ghga_connector/config.py
+++ b/ghga_connector/config.py
@@ -16,7 +16,7 @@
 
 """Global Config Parameters"""
 
-from ghga_service_chassis_lib.config import config_from_yaml
+from hexkit.config import config_from_yaml
 from pydantic import BaseSettings, Field
 
 from ghga_connector.core.constants import DEFAULT_PART_SIZE, MAX_RETRIES, MAX_WAIT_TIME

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,3 @@
 
 # additional requirements can be listed here
 testcontainers==3.4.1
-fastapi==0.94.1
-uvicorn[standard]==0.20.0
-ghga-service-chassis-lib[s3]==0.17.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,11 +35,10 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    httpyexpect==0.2.5
     typer==0.7.0
     crypt4gh==1.6
-    ghga-service-chassis-lib==0.17.7
-    ghga-service-commons[crypt]==0.3.2
+    ghga-service-commons[api, crypt]==0.3.2
+    hexkit[s3]==0.10.0
 
 python_requires = >= 3.9.10
 

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -16,20 +16,50 @@
 """Fixtures for testing the storage DAO"""
 
 from dataclasses import dataclass
-from typing import List
+from typing import AsyncGenerator, List
 
-from ghga_service_chassis_lib.object_storage_dao_testing import ObjectFixture
-from ghga_service_chassis_lib.s3_testing import (
-    S3Fixture,
-    s3_fixture_factory,
+import pytest
+from ghga_service_commons.utils.temp_files import big_temp_file
+from hexkit.providers.s3 import S3Config, S3ObjectStorage
+from hexkit.providers.s3.testutils import (
+    TEST_FILE_PATHS,
+    FileObject,
+    config_from_localstack_container,
     upload_file,
 )
-from ghga_service_chassis_lib.utils import big_temp_file
+from testcontainers.localstack import LocalStackContainer
 
 from . import state
 
+DEFAULT_EXISTING_BUCKETS = [
+    "myexistingtestbucket100",
+    "myexistingtestbucket200",
+]
+DEFAULT_NON_EXISTING_BUCKETS = [
+    "mynonexistingtestobject100",
+    "mynonexistingtestobject200",
+]
+
+DEFAULT_EXISTING_OBJECTS = [
+    FileObject(
+        file_path=file_path,
+        bucket_id=f"myexistingtestbucket{idx}",
+        object_id=f"myexistingtestobject{idx}",
+    )
+    for idx, file_path in enumerate(TEST_FILE_PATHS[0:2])
+]
+
+DEFAULT_NON_EXISTING_OBJECTS = [
+    FileObject(
+        file_path=file_path,
+        bucket_id=f"mynonexistingtestbucket{idx}",
+        object_id=f"mynonexistingtestobject{idx}",
+    )
+    for idx, file_path in enumerate(TEST_FILE_PATHS[2:4])
+]
+
 existing_buckets: List[str] = ["inbox", "outbox"]
-existing_objects: List[ObjectFixture] = []
+existing_objects: List[FileObject] = []
 
 for file in state.FILES.values():
     if file.populate_storage:
@@ -38,39 +68,107 @@ for file in state.FILES.values():
                 existing_buckets.append(storage_object.bucket_id)
             existing_objects.append(storage_object)
 
-s3_fixture = s3_fixture_factory(
-    existing_buckets=existing_buckets,
-    existing_objects=existing_objects,
+existing_buckets_ = (
+    DEFAULT_EXISTING_BUCKETS if existing_buckets is None else existing_buckets
 )
+non_existing_buckets_ = DEFAULT_NON_EXISTING_BUCKETS
+existing_objects_ = (
+    DEFAULT_EXISTING_OBJECTS if existing_objects is None else existing_objects
+)
+non_existing_objects_ = DEFAULT_NON_EXISTING_OBJECTS
+
+
+@dataclass
+class S3Fixture:
+    """Info yielded by the `s3_fixture` function"""
+
+    config: S3Config
+    storage: S3ObjectStorage
+    existing_buckets: List[str]
+    non_existing_buckets: List[str]
+    existing_objects: List[FileObject]
+    non_existing_objects: List[FileObject]
+
+
+async def populate_storage(
+    storage: S3ObjectStorage,
+    bucket_fixtures: List[str],
+    object_fixtures: List[FileObject],
+):
+    """Populate Storage with object and bucket fixtures"""
+
+    for bucket_fixture in bucket_fixtures:
+        await storage.create_bucket(bucket_fixture)
+
+    for object_fixture in object_fixtures:
+        if not await storage.does_bucket_exist(object_fixture.bucket_id):
+            await storage.create_bucket(object_fixture.bucket_id)
+
+        presigned_url = await storage.get_object_upload_url(
+            bucket_id=object_fixture.bucket_id, object_id=object_fixture.object_id
+        )
+
+        upload_file(
+            presigned_url=presigned_url,
+            file_path=object_fixture.file_path,
+            file_md5=object_fixture.md5,
+        )
+
+
+@pytest.fixture
+async def s3_fixture() -> S3Fixture:
+    """Pytest fixture for tests depending on the ObjectStorageS3 DAO."""
+    with LocalStackContainer(image="localstack/localstack:0.14.2").with_services(
+        "s3"
+    ) as localstack:
+        config = config_from_localstack_container(localstack)
+        storage = S3ObjectStorage(config=config)
+        await populate_storage(
+            storage=storage,
+            bucket_fixtures=existing_buckets_,
+            object_fixtures=existing_objects_,
+        )
+
+        assert not set(existing_buckets_) & set(  # nosec
+            non_existing_buckets_
+        ), "The existing and non existing bucket lists may not overlap"
+
+        yield S3Fixture(
+            config=config,
+            storage=storage,
+            existing_buckets=existing_buckets_,
+            non_existing_buckets=non_existing_buckets_,
+            existing_objects=existing_objects_,
+            non_existing_objects=non_existing_objects_,
+        )
 
 
 @dataclass
 class BigObjectS3Fixture(S3Fixture):
     """Extends the S3Fixture to include information on a big file stored on storage."""
 
-    big_object: ObjectFixture
+    big_object: FileObject
 
 
-def get_big_s3_object(
+async def get_big_s3_object(
     s3_fixture: S3Fixture, object_size: int = 20 * 1024 * 1024
-) -> ObjectFixture:
+) -> FileObject:
     """
     Extends the s3_fixture to also include a big file with the specified `file_size` on
     the provided s3 storage.
     """
-
     with big_temp_file(object_size) as big_file:
-        object_fixture = ObjectFixture(
+        object_fixture = FileObject(
             file_path=big_file.name,
             bucket_id=s3_fixture.existing_buckets[0],
             object_id="big-downloadable",
         )
 
         # upload file to s3
-        assert not s3_fixture.storage.does_object_exist(
+        assert not await s3_fixture.storage.does_object_exist(
             bucket_id=object_fixture.bucket_id, object_id=object_fixture.object_id
         )
-        presigned_url = s3_fixture.storage.get_object_upload_url(
+        presigned_url = await s3_fixture.storage.get_object_upload_url(
             bucket_id=object_fixture.bucket_id,
             object_id=object_fixture.object_id,
         )

--- a/tests/fixtures/state.py
+++ b/tests/fixtures/state.py
@@ -18,8 +18,7 @@
 from pathlib import Path
 from typing import Dict, List
 
-from ghga_service_chassis_lib.object_storage_dao_testing import ObjectFixture
-from ghga_service_chassis_lib.utils import TEST_FILE_PATHS
+from hexkit.providers.s3.testutils import TEST_FILE_PATHS, FileObject
 
 
 class FileState:
@@ -44,10 +43,10 @@ class FileState:
         self.file_path = file_path
         self.populate_storage = populate_storage
 
-        self.storage_objects: List[ObjectFixture] = []
+        self.storage_objects: List[FileObject] = []
         if self.populate_storage:
             self.storage_objects.append(
-                ObjectFixture(
+                FileObject(
                     file_path=self.file_path,
                     bucket_id=self.grouping_label,
                     object_id=self.file_id,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -60,9 +60,6 @@ async def test_multipart_download(
     monkeypatch,
 ):
     """Test the multipart download of a file"""
-    # workaround for now
-    s3_fixture = await s3_fixture.__anext__()
-
     big_object = await get_big_s3_object(s3_fixture, object_size=file_size)
 
     # The download function will ask the user for input.
@@ -153,9 +150,6 @@ async def test_download(
     monkeypatch,
 ):
     """Test the download of a file"""
-    # workaround for now
-    s3_fixture = await s3_fixture.__anext__()
-
     output_dir = Path("/non/existing/path") if bad_outdir else tmp_path
 
     file = state.FILES[file_name]
@@ -272,9 +266,6 @@ async def test_upload(
     s3_fixture: S3Fixture,  # noqa F811
 ):
     """Test the upload of a file, expects Abort, if the file was not found"""
-    # workaround for now
-    s3_fixture = await s3_fixture.__anext__()
-
     uploadable_file = state.FILES[file_name]
 
     if file_name == "encrypted_file":
@@ -348,9 +339,6 @@ async def test_multipart_upload(
     s3_fixture: S3Fixture,  # noqa F811
 ):
     """Test the upload of a file, expects Abort, if the file was not found"""
-    # workaround for now
-    s3_fixture = await s3_fixture.__anext__()
-
     bucket_id = s3_fixture.existing_buckets[0]
     file_id = "uploadable-" + str(anticipated_part_size)
 

--- a/tests/integration/test_file_operations.py
+++ b/tests/integration/test_file_operations.py
@@ -40,16 +40,20 @@ from tests.fixtures.s3 import S3Fixture, get_big_s3_object, s3_fixture  # noqa: 
         ),
     ],
 )
-def test_download_content_range(
+@pytest.mark.asyncio
+async def test_download_content_range(
     start: int,
     end: int,
     file_size: int,
     s3_fixture: S3Fixture,  # noqa: F811
 ):
     """Test the `download_content_range` function."""
+    # workaround for now
+    s3_fixture = await s3_fixture.__anext__()
+
     # prepare state and the expected result:
-    big_object = get_big_s3_object(s3_fixture, object_size=file_size)
-    download_url = s3_fixture.storage.get_object_download_url(
+    big_object = await get_big_s3_object(s3_fixture, object_size=file_size)
+    download_url = await s3_fixture.storage.get_object_download_url(
         object_id=big_object.object_id, bucket_id=big_object.bucket_id
     )
     expected_bytes = big_object.content[start : end + 1]
@@ -69,17 +73,21 @@ def test_download_content_range(
     "part_size",
     [5 * 1024 * 1024, 3 * 1024 * 1024, 1 * 1024 * 1024],
 )
-def test_download_file_parts(
+@pytest.mark.asyncio
+async def test_download_file_parts(
     part_size: int,
     s3_fixture: S3Fixture,  # noqa: F811
 ):
     """Test the `download_file_parts` function."""
+    # workaround for now
+    s3_fixture = await s3_fixture.__anext__()
+
     # prepare state and the expected result:
-    big_object = get_big_s3_object(s3_fixture)
+    big_object = await get_big_s3_object(s3_fixture)
     total_file_size = len(big_object.content)
     expected_bytes = big_object.content
 
-    download_url = s3_fixture.storage.get_object_download_url(
+    download_url = await s3_fixture.storage.get_object_download_url(
         object_id=big_object.object_id, bucket_id=big_object.bucket_id
     )
 

--- a/tests/integration/test_file_operations.py
+++ b/tests/integration/test_file_operations.py
@@ -48,9 +48,6 @@ async def test_download_content_range(
     s3_fixture: S3Fixture,  # noqa: F811
 ):
     """Test the `download_content_range` function."""
-    # workaround for now
-    s3_fixture = await s3_fixture.__anext__()
-
     # prepare state and the expected result:
     big_object = await get_big_s3_object(s3_fixture, object_size=file_size)
     download_url = await s3_fixture.storage.get_object_download_url(
@@ -79,9 +76,6 @@ async def test_download_file_parts(
     s3_fixture: S3Fixture,  # noqa: F811
 ):
     """Test the `download_file_parts` function."""
-    # workaround for now
-    s3_fixture = await s3_fixture.__anext__()
-
     # prepare state and the expected result:
     big_object = await get_big_s3_object(s3_fixture)
     total_file_size = len(big_object.content)

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -24,7 +24,7 @@ from typing import Optional
 
 import crypt4gh.keys
 import pytest
-from ghga_service_chassis_lib.utils import big_temp_file
+from ghga_service_commons.utils.temp_files import big_temp_file
 
 from ghga_connector.core.file_operations import (
     Crypt4GHDecryptor,


### PR DESCRIPTION
```
Replaced chassis lib with hexkit & service-commons
Moved custom chassis-lib S3Fixture into connector
```

Especially the stuff moved over from chassis-lib might need some further cleanup work, but that can be included in the MockAPI -> pytest-httpx ticket further down the line.