### PR TITLE
Add default WKVS url (GSI-287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:0.3.7
+docker pull ghga/ghga-connector:0.3.8
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:0.3.7 .
+docker build -t ghga/ghga-connector:0.3.8 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -42,7 +42,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-connector:0.3.7 --help
+docker run -p 8080:8080 ghga/ghga-connector:0.3.8 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The service requires the following configuration parameters:
 
 - **`part_size`** *(integer)*: The part size to use for download. Default: `16777216`.
 
-- **`wkvs_api_url`** *(string)*: URL to the root of the WKVS API. Should start with https://.
+- **`wkvs_api_url`** *(string)*: URL to the root of the WKVS API. Should start with https://. Default: `https://data.ghga.de/.well-known`.
 
 
 ### Usage:

--- a/config_schema.json
+++ b/config_schema.json
@@ -33,14 +33,12 @@
     "wkvs_api_url": {
       "title": "Wkvs Api Url",
       "description": "URL to the root of the WKVS API. Should start with https://",
+      "default": "https://data.ghga.de/.well-known",
       "env_names": [
         "ghga_connector_wkvs_api_url"
       ],
       "type": "string"
     }
   },
-  "required": [
-    "wkvs_api_url"
-  ],
   "additionalProperties": false
 }

--- a/ghga_connector/__init__.py
+++ b/ghga_connector/__init__.py
@@ -17,4 +17,4 @@
 CLI - Client to perform up- and download operations to and from a local ghga instance
 """
 
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -101,10 +101,10 @@ def upload(  # noqa C901
 
 
 if strtobool(os.getenv("UPLOAD_ENABLED") or "false"):
-    cli.command()(upload)
+    cli.command(no_args_is_help=True)(upload)
 
 
-@cli.command()
+@cli.command(no_args_is_help=True)
 def download(  # pylint: disable=too-many-arguments,too-many-locals
     *,
     output_dir: Path = typer.Option(
@@ -199,7 +199,7 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
         file_stager.update_staged_files()
 
 
-@cli.command()
+@cli.command(no_args_is_help=True)
 def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
     *,
     input_dir: Path = typer.Option(

--- a/ghga_connector/config.py
+++ b/ghga_connector/config.py
@@ -37,5 +37,6 @@ class Config(BaseSettings):
         DEFAULT_PART_SIZE, description="The part size to use for download."
     )
     wkvs_api_url: str = Field(
-        ..., description="URL to the root of the WKVS API. Should start with https://"
+        "https://data.ghga.de/.well-known",
+        description="URL to the root of the WKVS API. Should start with https://",
     )

--- a/ghga_connector/core/api_calls/upload.py
+++ b/ghga_connector/core/api_calls/upload.py
@@ -66,7 +66,7 @@ def initiate_multipart_upload(
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
     public_key = base64.b64encode(crypt4gh.keys.get_public_key(pubkey_path)).decode()
 
-    post_data = {"file_id": file_id, "submitter_public_key": public_key}
+    post_data = {"file_id": file_id, "user_public_key": public_key}
     serialized_data = json.dumps(post_data)
 
     # Make function call to get upload url

--- a/ghga_connector/core/api_calls/work_package.py
+++ b/ghga_connector/core/api_calls/work_package.py
@@ -33,7 +33,7 @@ class WorkPackageAccessor:
     api_url: str
     dcs_api_url: str
     package_id: str
-    submitter_private_key: str
+    user_private_key: str
 
     def get_package_files(self) -> dict[str, str]:
         """
@@ -88,7 +88,7 @@ class WorkPackageAccessor:
             raise exceptions.InvalidWPSResponseError(url=url, response_code=status_code)
 
         encrypted_token = response.content
-        return _decrypt(data=encrypted_token, key=self.submitter_private_key)
+        return _decrypt(data=encrypted_token, key=self.user_private_key)
 
 
 def _decrypt(*, data: str, key: str):

--- a/ghga_connector/core/file_operations.py
+++ b/ghga_connector/core/file_operations.py
@@ -42,16 +42,16 @@ class Crypt4GHEncryptor:
     def __init__(
         self,
         server_pubkey: str,
-        submitter_private_key_path: Path,
+        user_private_key_path: Path,
     ) -> None:
         self.server_public = base64.b64decode(server_pubkey)
-        self.submitter_private = crypt4gh.keys.get_private_key(
-            submitter_private_key_path, callback=None
+        self.user_private_key = crypt4gh.keys.get_private_key(
+            user_private_key_path, callback=None
         )
 
     def encrypt_file(self, *, file_path: Path) -> Path:
         """Encrypt provided file using Crypt4GH lib"""
-        keys = [(0, self.submitter_private, self.server_public)]
+        keys = [(0, self.user_private_key, self.server_public)]
         with file_path.open("rb") as infile:
             # NamedTemporaryFile cannot be opened a second time on Windows, manually
             # deal with setup + teardown instead

--- a/ghga_connector/core/main.py
+++ b/ghga_connector/core/main.py
@@ -52,23 +52,21 @@ def upload(  # noqa C901, pylint: disable=too-many-statements,too-many-branches
     file_path: Path,
     message_display: AbstractMessageDisplay,
     server_pubkey: str,
-    submitter_pubkey_path: Path,
-    submitter_private_key_path: Path,
+    user_public_key_path: Path,
+    user_private_key_path: Path,
 ) -> None:
     """
     Core command to upload a file. Can be called by CLI, GUI, etc.
     """
 
-    if not submitter_pubkey_path.is_file():
-        message_display.failure(f"The file {submitter_pubkey_path} does not exist.")
-        raise exceptions.PubKeyFileDoesNotExistError(pubkey_path=submitter_pubkey_path)
+    if not user_public_key_path.is_file():
+        message_display.failure(f"The file {user_public_key_path} does not exist.")
+        raise exceptions.PubKeyFileDoesNotExistError(pubkey_path=user_public_key_path)
 
-    if not submitter_private_key_path.is_file():
-        message_display.failure(
-            f"The file {submitter_private_key_path} does not exist."
-        )
+    if not user_private_key_path.is_file():
+        message_display.failure(f"The file {user_private_key_path} does not exist.")
         raise exceptions.PrivateKeyFileDoesNotExistError(
-            private_key_path=submitter_private_key_path
+            private_key_path=user_private_key_path
         )
 
     if not file_path.is_file():
@@ -89,7 +87,7 @@ def upload(  # noqa C901, pylint: disable=too-many-statements,too-many-branches
 
     try:
         upload_id, part_size = start_multipart_upload(
-            api_url=api_url, file_id=file_id, pubkey_path=submitter_pubkey_path
+            api_url=api_url, file_id=file_id, pubkey_path=user_public_key_path
         )
     except exceptions.NoUploadPossibleError as error:
         message_display.failure(
@@ -123,7 +121,7 @@ def upload(  # noqa C901, pylint: disable=too-many-statements,too-many-branches
 
     encryptor = Crypt4GHEncryptor(
         server_pubkey=server_pubkey,
-        submitter_private_key_path=submitter_private_key_path,
+        user_private_key_path=user_private_key_path,
     )
 
     encrypted_file_path = encryptor.encrypt_file(file_path=file_path)
@@ -185,7 +183,7 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     part_size: int,
     message_display: AbstractMessageDisplay,
     max_wait_time: int,
-    submitter_public_key: bytes,
+    user_public_key: bytes,
     work_package_accessor: WorkPackageAccessor,
     file_id: str,
     file_extension: str = "",
@@ -226,7 +224,7 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     try:
         envelope = get_file_header_envelope(
             file_id=file_id,
-            public_key=submitter_public_key,
+            public_key=user_public_key,
             work_package_accessor=work_package_accessor,
         )
     except (

--- a/ghga_connector/core/main.py
+++ b/ghga_connector/core/main.py
@@ -331,13 +331,18 @@ def get_wps_token(max_tries: int, message_display: AbstractMessageDisplay) -> Li
     """
     for _ in range(max_tries):
         work_package_string = input(
-            "Paste the complete work package string you got from the UI: "
+            "Please paste the complete download token "
+            + "that you copied from the GHGA data portal: "
         )
         work_package_parts = work_package_string.split(":")
-        if len(work_package_parts) != 2:
+        if not (
+            len(work_package_parts) == 2
+            and 20 <= len(work_package_parts[0]) < 40
+            and 80 <= len(work_package_parts[1]) < 120
+        ):
             message_display.display(
-                "Invalid input. Please enter the work package string you got from the "
-                + "UI unaltered."
+                "Invalid input. Please enter the download token "
+                + "you got from the GHGA data portal unaltered."
             )
             continue
         return work_package_parts

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -137,8 +137,8 @@ async def test_multipart_download(
     ):
         download(
             output_dir=tmp_path,
-            submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-            submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+            user_public_key_path=Path(PUBLIC_KEY_FILE),
+            user_private_key_path=Path(PRIVATE_KEY_FILE),
         )
 
     with open(tmp_path / f"{big_object.object_id}.c4gh", "rb") as file:
@@ -249,8 +249,8 @@ async def test_download(
                     ):
                         download(
                             output_dir=output_dir,
-                            submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-                            submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+                            user_public_key_path=Path(PUBLIC_KEY_FILE),
+                            user_private_key_path=Path(PRIVATE_KEY_FILE),
                         )
                 with patch(
                     "ghga_connector.core.api_calls.work_package._decrypt",
@@ -262,8 +262,8 @@ async def test_download(
                     ):
                         download(
                             output_dir=output_dir,
-                            submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-                            submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+                            user_public_key_path=Path(PUBLIC_KEY_FILE),
+                            user_private_key_path=Path(PRIVATE_KEY_FILE),
                         )
             else:
                 with pytest.raises(  # type: ignore
@@ -271,8 +271,8 @@ async def test_download(
                 ) if expected_exception else nullcontext():
                     download(
                         output_dir=output_dir,
-                        submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-                        submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+                        user_public_key_path=Path(PUBLIC_KEY_FILE),
+                        user_private_key_path=Path(PRIVATE_KEY_FILE),
                     )
 
         # BadResponseCode is no longer propagated and file at path does not exist
@@ -325,7 +325,7 @@ async def test_upload(
             crypt4gh.keys.get_public_key(PUBLIC_KEY_FILE)
         ).decode("utf-8")
         encryptor = Crypt4GHEncryptor(
-            server_pubkey=server_pubkey, submitter_private_key_path=PRIVATE_KEY_FILE
+            server_pubkey=server_pubkey, user_private_key_path=PRIVATE_KEY_FILE
         )
         encrypted_path = encryptor.encrypt_file(file_path=uploadable_file.file_path)
 
@@ -359,15 +359,15 @@ async def test_upload(
                 upload(
                     file_id=uploadable_file.file_id,
                     file_path=Path(encrypted_path).resolve(),
-                    submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-                    submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+                    user_public_key_path=Path(PUBLIC_KEY_FILE),
+                    user_private_key_path=Path(PRIVATE_KEY_FILE),
                 )
             else:
                 upload(
                     file_id=uploadable_file.file_id,
                     file_path=uploadable_file.file_path.resolve(),
-                    submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-                    submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+                    user_public_key_path=Path(PUBLIC_KEY_FILE),
+                    user_private_key_path=Path(PRIVATE_KEY_FILE),
                 )
 
             await s3_fixture.storage.complete_multipart_upload(
@@ -455,8 +455,8 @@ async def test_multipart_upload(
             upload(
                 file_id=file_id,
                 file_path=Path(file.name),
-                submitter_pubkey_path=Path(PUBLIC_KEY_FILE),
-                submitter_private_key_path=Path(PRIVATE_KEY_FILE),
+                user_public_key_path=Path(PUBLIC_KEY_FILE),
+                user_private_key_path=Path(PRIVATE_KEY_FILE),
             )
 
     # confirm upload

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -161,7 +161,7 @@ def test_get_wps_file_info(httpx_mock: HTTPXMock):
         api_url="http://127.0.0.1",
         dcs_api_url="",
         package_id=wp_id,
-        submitter_private_key="",
+        user_private_key="",
     )
     response = work_package_accessor.get_package_files()
     assert response == files
@@ -175,7 +175,7 @@ def test_get_wps_file_info(httpx_mock: HTTPXMock):
             api_url="http://127.0.0.1",
             dcs_api_url="",
             package_id=wp_id,
-            submitter_private_key="",
+            user_private_key="",
         )
         response = work_package_accessor.get_package_files()
 
@@ -188,7 +188,7 @@ def test_get_wps_file_info(httpx_mock: HTTPXMock):
             api_url="http://127.0.0.1",
             dcs_api_url="",
             package_id=wp_id,
-            submitter_private_key="",
+            user_private_key="",
         )
         response = work_package_accessor.get_package_files()
 

--- a/tests/unit/test_file_operations.py
+++ b/tests/unit/test_file_operations.py
@@ -78,7 +78,7 @@ def test_encryption_decryption():
 
             # produce encrypted file
             encryptor = Crypt4GHEncryptor(
-                server_pubkey=pubkey, submitter_private_key_path=private_key_path
+                server_pubkey=pubkey, user_private_key_path=private_key_path
             )
             encrypted_file_loc = encryptor.encrypt_file(file_path=Path(in_file.name))
 


### PR DESCRIPTION
Added the base url for the WKVS config item as supplied in the ticket (https://data.ghga.de/.well-known).

Renamed instances of submitter_private/public_key and existing variations to user_private_key and user_public_key.

Enabled no_args_is_help for CLI subcommands.