### PR TITLE
Fix fetching the work order token

### DIFF
--- a/ghga_connector/core/api_calls/work_package.py
+++ b/ghga_connector/core/api_calls/work_package.py
@@ -87,7 +87,9 @@ class WorkPackageAccessor:
                 )
             raise exceptions.InvalidWPSResponseError(url=url, response_code=status_code)
 
-        encrypted_token = response.content
+        encrypted_token = response.json()
+        if not encrypted_token or not isinstance(encrypted_token, str):
+            raise exceptions.InvalidWPSResponseError(url=url, response_code=status_code)
         return _decrypt(data=encrypted_token, key=self.submitter_private_key)
 
 

--- a/ghga_connector/core/batch_processing.py
+++ b/ghga_connector/core/batch_processing.py
@@ -273,7 +273,7 @@ class FileStager:  # pylint: disable=too-many-instance-attributes
     def _handle_unknown(self, unknown_ids: list[str]):
         """Process user interaction for unknown file IDs"""
         message = (
-            f"No download exists for the following file IDs: {' ,'.join(unknown_ids)}"
+            f"No download exists for the following file IDs: {', '.join(unknown_ids)}"
         )
         self.message_display.failure(message)
 

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -71,7 +71,7 @@ class PubKeyFileDoesNotExistError(RuntimeError):
         super().__init__(message)
 
 
-class PubkeyMismatchError(RuntimeError):
+class PubKeyMismatchError(RuntimeError):
     """
     Thrown when the user public key announced in the submission metadata retrieved from
     the work package service does not match the user public key provided to the connector

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -305,7 +305,7 @@ class NoWorkPackageAccessError(RuntimeError):
 class InvalidWPSResponseError(RuntimeError):
     """
     Thrown when communication with the Work Package Service returns an unexpected response.
-    This should be used instead of BadResponseError when handling WPS results to differntiate
+    This should be used instead of BadResponseError when handling WPS results to differentiate.
     """
 
     def __init__(self, *, url: str, response_code: int):

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -457,10 +457,7 @@ def mock_wkvs(value_name: str):
     }
 
     if value_name in values:
-        return httpx.Response(
-            status_code=200,
-            json={value_name: values[value_name]},
-        )
+        return httpx.Response(status_code=200, json={value_name: values[value_name]})
     else:
         raise HttpyException(
             status_code=404,

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -456,15 +456,14 @@ def mock_wkvs(value_name: str):
         "ucs_api_url": "http://127.0.0.1/upload",
     }
 
-    if value_name in values:
-        return httpx.Response(status_code=200, json={value_name: values[value_name]})
-    else:
+    if value_name not in values:
         raise HttpyException(
             status_code=404,
             exception_id="valueNotConfigured",
             description=f"The value {value_name} is not configured.",
             data={"value_name": value_name},
         )
+    return httpx.Response(status_code=200, json={value_name: values[value_name]})
 
 
 def handle_request(request: httpx.Request):

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -441,7 +441,8 @@ def create_work_order_token(package_id: str, file_id: str):
 
     # has to be at least 48 chars long
     return httpx.Response(
-        status_code=201, content=base64.b64encode(b"1234567890" * 5).decode()
+        status_code=201,
+        json=base64.b64encode(b"1234567890" * 5).decode(),
     )
 
 


### PR DESCRIPTION
The response from FastAPI is always JSON, even for scalar values.