### PR TITLE
Remove redundant error messaging (GSI 304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:0.3.8
+docker pull ghga/ghga-connector:0.3.9
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:0.3.8 .
+docker build -t ghga/ghga-connector:0.3.9 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -42,7 +42,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-connector:0.3.8 --help
+docker run -p 8080:8080 ghga/ghga-connector:0.3.9 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/ghga_connector/__init__.py
+++ b/ghga_connector/__init__.py
@@ -17,4 +17,4 @@
 CLI - Client to perform up- and download operations to and from a local ghga instance
 """
 
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -259,7 +259,7 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
         output_dir = Path(os.getcwd())
 
     if output_dir.exists() and not output_dir.is_dir():
-        raise core.exceptions.DirectoryIsNotDirectory(directory=output_dir)
+        raise core.exceptions.PathIsNotDirectory(directory=output_dir)
 
     if not output_dir.exists():
         message_display.display(f"Creating output directory '{output_dir}'")

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -19,7 +19,10 @@
 import os
 import sys
 from distutils.util import strtobool
+from functools import partial
 from pathlib import Path
+from types import TracebackType
+from typing import Union
 
 import crypt4gh.keys
 import typer
@@ -56,6 +59,25 @@ class CLIMessageDisplay(core.AbstractMessageDisplay):
         typer.secho(message, fg=core.MessageColors.FAILURE, err=True)
 
 
+def exception_hook(
+    type_: BaseException,  # pylint: disable=unused-argument
+    value: BaseException,
+    traceback: Union[TracebackType, None],  # pylint: disable=unused-argument
+    message_display: CLIMessageDisplay,
+):
+    """When debug mode is NOT enabled, gets called to perform final error handling
+    before program exits"""
+    message = (
+        "An error occurred. Run same command"
+        + "with --debug at the end to see more information."
+    )
+
+    if value.args:
+        message = value.args[0]
+
+    message_display.failure(message)
+
+
 cli = typer.Typer(no_args_is_help=True)
 
 
@@ -80,8 +102,10 @@ def upload(  # noqa C901
     """
     Command to upload a file
     """
+    message_display = CLIMessageDisplay()
+
     if not debug:
-        sys.excepthook = lambda x, y, z: None
+        sys.excepthook = partial(exception_hook, message_display=message_display)
 
     core.HttpxClientState.configure(CONFIG.max_retries)
 
@@ -128,21 +152,20 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
     """
     Command to download files
     """
-    if not debug:
-        sys.excepthook = lambda x, y, z: None
 
     core.HttpxClientState.configure(CONFIG.max_retries)
     message_display = CLIMessageDisplay()
 
+    if not debug:
+        sys.excepthook = partial(exception_hook, message_display=message_display)
+
     if not my_public_key_path.is_file():
-        message_display.failure(f"The file '{my_public_key_path}' does not exist.")
         raise core.exceptions.PubKeyFileDoesNotExistError(
             pubkey_path=my_public_key_path
         )
 
     if not output_dir.is_dir():
-        message_display.failure(f"The directory '{output_dir}' does not exist.")
-        raise core.exceptions.DirectoryDoesNotExistError(output_dir=output_dir)
+        raise core.exceptions.DirectoryDoesNotExistError(directory=output_dir)
 
     my_public_key = crypt4gh.keys.get_public_key(filepath=my_public_key_path)
     my_private_key = crypt4gh.keys.get_private_key(
@@ -155,6 +178,7 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
     )
     decrypted_token = crypt.decrypt(data=work_package_token, key=my_private_key)
 
+    message_display.display("Retrieving API configuration information...")
     wkvs_caller = core.WKVSCaller(CONFIG.wkvs_api_url)
     wps_api_url = wkvs_caller.get_wps_api_url()
     dcs_api_url = wkvs_caller.get_dcs_api_url()
@@ -185,6 +209,7 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
 
     while file_stager.file_ids_remain():
         for file_id in file_stager.get_staged():
+            message_display.display(f"Downloading file with id '{file_id}'...")
             core.download(
                 api_url=dcs_api_url,
                 file_id=file_id,
@@ -222,33 +247,33 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
 ):
     """Command to decrypt a downloaded file"""
 
-    if not debug:
-        sys.excepthook = lambda x, y, z: None
-
     message_display = CLIMessageDisplay()
 
+    if not debug:
+        sys.excepthook = partial(exception_hook, message_display=message_display)
+
     if not input_dir.is_dir():
-        message_display.failure(
-            f"Input directory '{input_dir}' does not exist or is not a directory."
-        )
+        raise core.exceptions.DirectoryDoesNotExistError(directory=input_dir)
 
     if not output_dir:
         output_dir = Path(os.getcwd())
 
     if output_dir.exists() and not output_dir.is_dir():
-        message_display.failure(
-            f"Output directory location '{input_dir}' exists, but is not a directory."
-        )
+        raise core.exceptions.DirectoryIsNotDirectory(directory=output_dir)
 
     if not output_dir.exists():
+        message_display.display(f"Creating output directory '{output_dir}'")
         output_dir.mkdir(parents=True)
 
     errors = {}
     skipped_files = []
+    file_count = 0
     for input_file in input_dir.iterdir():
         if not input_file.is_file() or not input_file.suffix == ".c4gh":
             skipped_files.append((str(input_file)))
             continue
+
+        file_count += 1
 
         # strip the .c4gh extension for the output file
         output_file = output_dir / input_file.with_suffix("")
@@ -260,6 +285,7 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
             continue
 
         try:
+            message_display.display(f"Decrypting file with id '{input_file}'...")
             core.decrypt_file(
                 input_file=input_file,
                 output_file=output_file,
@@ -273,6 +299,11 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
 
         message_display.success(
             f"Successfully decrypted file '{input_file}' to location '{output_dir}'."
+        )
+    if file_count == 0:
+        message_display.display(
+            f"No files were processed because the directory '{input_dir}' contains no "
+            + "applicable files."
         )
 
     if skipped_files:

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -259,7 +259,7 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
         output_dir = Path(os.getcwd())
 
     if output_dir.exists() and not output_dir.is_dir():
-        raise core.exceptions.PathIsNotDirectory(directory=output_dir)
+        raise core.exceptions.OutputPathIsNotDirectory(directory=output_dir)
 
     if not output_dir.exists():
         message_display.display(f"Creating output directory '{output_dir}'")

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -68,7 +68,7 @@ def exception_hook(
     """When debug mode is NOT enabled, gets called to perform final error handling
     before program exits"""
     message = (
-        "An error occurred. Run same command"
+        "An error occurred. Rerun command"
         + " with --debug at the end to see more information."
     )
 

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -69,7 +69,7 @@ def exception_hook(
     before program exits"""
     message = (
         "An error occurred. Run same command"
-        + "with --debug at the end to see more information."
+        + " with --debug at the end to see more information."
     )
 
     if value.args:

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -34,8 +34,18 @@ class AbortBatchProcessError(RuntimeError):
 class DirectoryDoesNotExistError(RuntimeError):
     """Thrown, when the specified directory does not exist."""
 
-    def __init__(self, *, output_dir: Path):
-        message = f"The directory {output_dir} does not exist."
+    def __init__(self, *, directory: Path):
+        message = f"The directory '{directory}' does not exist."
+        super().__init__(message)
+
+
+class DirectoryIsNotDirectory(RuntimeError):
+    """Thrown when specified directory is not a directory"""
+
+    def __init__(self, *, directory: Path):
+        message = (
+            f"Output directory location '{directory}' exists, but is not a directory."
+        )
         super().__init__(message)
 
 
@@ -43,7 +53,7 @@ class FileAlreadyExistsError(RuntimeError):
     """Thrown, when the specified file already exists."""
 
     def __init__(self, *, output_file: str):
-        message = f"The file {output_file} already exists."
+        message = f"The file '{output_file}' already exists."
         super().__init__(message)
 
 
@@ -51,7 +61,7 @@ class FileAlreadyEncryptedError(RuntimeError):
     """Thrown, when the specified file is already encrypted."""
 
     def __init__(self, *, file_path: Path):
-        message = f"The file {file_path} is already Crypt4GH encrypted."
+        message = f"The file '{file_path}' is already Crypt4GH encrypted."
         super().__init__(message)
 
 
@@ -59,7 +69,7 @@ class FileDoesNotExistError(RuntimeError):
     """Thrown, when the specified file does not exist."""
 
     def __init__(self, *, file_path: Path):
-        message = f"The file {file_path} does not exist."
+        message = f"The file '{file_path}' does not exist."
         super().__init__(message)
 
 
@@ -67,7 +77,7 @@ class PubKeyFileDoesNotExistError(RuntimeError):
     """Thrown, when the specified public key file does not exist."""
 
     def __init__(self, *, pubkey_path: Path):
-        message = f"The public key file {pubkey_path} does not exist."
+        message = f"The public key file '{pubkey_path}' does not exist."
         super().__init__(message)
 
 
@@ -88,7 +98,7 @@ class PrivateKeyFileDoesNotExistError(RuntimeError):
     """Thrown, when the specified private key file does exist."""
 
     def __init__(self, *, private_key_path: Path):
-        message = f"The private key file {private_key_path} does not exist."
+        message = f"The private key file '{private_key_path}' does not exist."
         super().__init__(message)
 
 
@@ -96,7 +106,7 @@ class ApiNotReachableError(RuntimeError):
     """Thrown, when the api is not reachable."""
 
     def __init__(self, *, api_url: str):
-        message = f"The url {api_url} is currently not reachable."
+        message = f"The url '{api_url}' is currently not reachable."
         super().__init__(message)
 
 
@@ -104,9 +114,7 @@ class RetryTimeExpectedError(RuntimeError):
     """Thrown, when a request didn't contain a retry time even though it was expected."""
 
     def __init__(self, *, url: str):
-        message = (
-            f"No `Retry-After` header in response from server following the url: {url}"
-        )
+        message = f"No `Retry-After` header in response from server following the url: '{url}'"
         super().__init__(message)
 
 
@@ -114,7 +122,7 @@ class RequestFailedError(RuntimeError):
     """Thrown, when a request fails without returning a response code"""
 
     def __init__(self, *, url: str):
-        message = f"The request to {url} failed."
+        message = f"The request to '{url}' failed."
         super().__init__(message)
 
 
@@ -123,7 +131,7 @@ class NoS3AccessMethodError(RuntimeError):
     Method"""
 
     def __init__(self, *, url: str):
-        message = f"The request to {url} did not return an S3 Access Method."
+        message = f"The request to '{url}' did not return an S3 Access Method."
         super().__init__(message)
 
 
@@ -154,7 +162,7 @@ class BadResponseCodeError(RuntimeError):
 
     def __init__(self, *, url: str, response_code: int):
         self.response_code = response_code
-        message = f"The request to {url} failed with response code {response_code}."
+        message = f"The request to '{url}' failed with response code {response_code}."
         super().__init__(message)
 
 
@@ -179,7 +187,7 @@ class DownloadFinalizationError(RuntimeError):
     def __init__(self, *, file_path: Path):
         message = (
             "Cannot move downloaded file to its final location as another file "
-            + f"unexpectedly exists at {file_path}"
+            + f"unexpectedly exists at '{file_path}'"
         )
         super().__init__(message)
 
@@ -229,7 +237,7 @@ class MaxWaitTimeExceededError(RuntimeError):
     exceeded."""
 
     def __init__(self, *, max_wait_time: int):
-        message = f"Exceeded maximum wait time of {max_wait_time} seconds."
+        message = f"Exceeded maximum wait time of ({max_wait_time}) seconds."
         super().__init__(message)
 
 
@@ -237,7 +245,7 @@ class ConnectionFailedError(RuntimeError):
     """Thrown, when a ConnectError or ConnectTimeout error is raised by httpx"""
 
     def __init__(self, *, url: str, reason: str):
-        message = f"Request to {url} failed to connect. Reason: {reason}"
+        message = f"Request to '{url}' failed to connect. Reason: {reason}"
         super().__init__(message)
 
 
@@ -284,7 +292,7 @@ class InvalidWorkPackageToken(RuntimeError):
     """Thrown, when the work package string pasted by the user could not be parsed"""
 
     def __init__(self, *, tries: int):
-        message = f"Parsing of the work package string failed {tries} times."
+        message = f"Parsing of the work package string failed ({tries}) times."
         super().__init__(message)
 
 
@@ -311,7 +319,7 @@ class InvalidWPSResponseError(RuntimeError):
     def __init__(self, *, url: str, response_code: int):
         self.response_code = response_code
         message = (
-            f"The request to the WPS at {url} failed with an unexpected response code "
+            f"The request to the WPS at '{url}' failed with an unexpected response code "
             + f"of {response_code}."
         )
         super().__init__(message)
@@ -323,7 +331,7 @@ class UnauthorizedAPICallError(RuntimeError):
     """
 
     def __init__(self, *, url: str, cause: str):
-        message = f"Could not authorize call to {url}: {cause}"
+        message = f"Could not authorize call to '{url}': {cause}"
         super().__init__(message)
 
 

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -61,7 +61,10 @@ class FileAlreadyEncryptedError(RuntimeError):
     """Thrown, when the specified file is already encrypted."""
 
     def __init__(self, *, file_path: Path):
-        message = f"The file '{file_path}' is already Crypt4GH encrypted."
+        message = (
+            f"The file '{file_path}' is already Crypt4GH encrypted. Provide data "
+            + "without Crypt4GH encryption."
+        )
         super().__init__(message)
 
 
@@ -88,9 +91,7 @@ class PubKeyMismatchError(RuntimeError):
     """
 
     def __init__(self):
-        message = (
-            "Provided user public key does not match the announced user public key."
-        )
+        message = "Provided public key does not match the public key from the metadata."
         super().__init__(message)
 
 
@@ -172,7 +173,7 @@ class NoUploadPossibleError(RuntimeError):
     def __init__(self, *, file_id: str):
         message = (
             "It is not possible to start a multipart upload for file with id "
-            + f"'{file_id}', because this download is already pending or has been "
+            + f"'{file_id}' because this download is already pending or has been "
             + "accepted."
         )
         super().__init__(message)
@@ -201,7 +202,7 @@ class UserHasNoUploadAccessError(RuntimeError):
 
     def __init__(self, *, upload_id: str):
         message = (
-            "This user is not registered as the data submitter "
+            "User is not registered as a Data Submitter "
             f"for the file corresponding to the upload_id '{upload_id}'."
         )
         super().__init__(message)
@@ -215,7 +216,7 @@ class UserHasNoFileAccessError(RuntimeError):
 
     def __init__(self, *, file_id: str):
         message = (
-            "This user is not registered as the data submitter "
+            "User is not registered as the data submitter "
             f"for the file with the id '{file_id}'."
         )
         super().__init__(message)

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -39,12 +39,12 @@ class DirectoryDoesNotExistError(RuntimeError):
         super().__init__(message)
 
 
-class DirectoryIsNotDirectory(RuntimeError):
+class PathIsNotDirectory(RuntimeError):
     """Thrown when specified directory is not a directory"""
 
     def __init__(self, *, directory: Path):
         message = (
-            f"Output directory location '{directory}' exists, but is not a directory."
+            f"Path of output directory '{directory}' exists, but is not a directory."
         )
         super().__init__(message)
 

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -39,8 +39,8 @@ class DirectoryDoesNotExistError(RuntimeError):
         super().__init__(message)
 
 
-class PathIsNotDirectory(RuntimeError):
-    """Thrown when specified directory is not a directory"""
+class OutputPathIsNotDirectory(RuntimeError):
+    """Thrown when specified output path is not a directory"""
 
     def __init__(self, *, directory: Path):
         message = (

--- a/ghga_connector/core/exceptions.py
+++ b/ghga_connector/core/exceptions.py
@@ -202,7 +202,7 @@ class UserHasNoUploadAccessError(RuntimeError):
 
     def __init__(self, *, upload_id: str):
         message = (
-            "User is not registered as a Data Submitter "
+            "You are not registered as a Data Submitter "
             f"for the file corresponding to the upload_id '{upload_id}'."
         )
         super().__init__(message)
@@ -216,7 +216,7 @@ class UserHasNoFileAccessError(RuntimeError):
 
     def __init__(self, *, file_id: str):
         message = (
-            "User is not registered as the data submitter "
+            "You are not registered as the data submitter "
             f"for the file with the id '{file_id}'."
         )
         super().__init__(message)

--- a/ghga_connector/core/main.py
+++ b/ghga_connector/core/main.py
@@ -60,29 +60,20 @@ def upload(  # noqa C901, pylint: disable=too-many-statements,too-many-branches
     """
 
     if not my_public_key_path.is_file():
-        message_display.failure(f"The file {my_public_key_path} does not exist.")
         raise exceptions.PubKeyFileDoesNotExistError(pubkey_path=my_public_key_path)
 
     if not my_private_key_path.is_file():
-        message_display.failure(f"The file {my_private_key_path} does not exist.")
         raise exceptions.PrivateKeyFileDoesNotExistError(
             private_key_path=my_private_key_path
         )
 
     if not file_path.is_file():
-        message_display.failure(f"The file {file_path} does not exist.")
         raise exceptions.FileDoesNotExistError(file_path=file_path)
 
     if is_file_encrypted(file_path):
-        message_display.failure(
-            f"The file {file_path} is already Crypt4GH encrypted."
-            + "\nThis is currently not supported."
-            + " Please provide your data without Crypt4GH encryption."
-        )
         raise exceptions.FileAlreadyEncryptedError(file_path=file_path)
 
     if not check_url(api_url):
-        message_display.failure(f"The url {api_url} is not currently reachable.")
         raise exceptions.ApiNotReachableError(api_url=api_url)
 
     try:
@@ -90,27 +81,14 @@ def upload(  # noqa C901, pylint: disable=too-many-statements,too-many-branches
             api_url=api_url, file_id=file_id, pubkey_path=my_public_key_path
         )
     except exceptions.NoUploadPossibleError as error:
-        message_display.failure(
-            f"This user can't start a multipart upload for the file_id '{file_id}'"
-        )
         raise error
     except exceptions.UploadNotRegisteredError as error:
-        message_display.failure(
-            f"The pending upload for file '{file_id}' does not exist."
-        )
         raise error
     except exceptions.UserHasNoUploadAccessError as error:
-        message_display.failure(
-            f"The user is not registered as a Data Submitter for the file with id '{file_id}'."
-        )
         raise error
     except exceptions.FileNotRegisteredError as error:
-        message_display.failure(f"The file with the id '{file_id}' is not registered.")
         raise error
     except exceptions.BadResponseCodeError as error:
-        message_display.failure(
-            "The request was invalid and returned a bad HTTP status code."
-        )
         raise error
     except exceptions.CantChangeUploadStatusError as error:
         message_display.failure(f"The file with id '{file_id}' was already uploaded.")
@@ -193,7 +171,6 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     """
 
     if not check_url(api_url):
-        message_display.failure(f"The url {api_url} is not currently reachable.")
         raise exceptions.ApiNotReachableError(api_url=api_url)
 
     # construct file name with suffix, if given
@@ -204,7 +181,6 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     # check output file
     output_file = output_dir / f"{file_name}.c4gh"
     if output_file.exists():
-        message_display.failure(f"The file {output_file} already exists.")
         raise exceptions.FileAlreadyExistsError(output_file=str(output_file))
 
     # with_suffix() might overwrite existing suffixes, do this instead
@@ -252,10 +228,6 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
         output_file_ongoing.unlink()
         raise error
     except exceptions.NoS3AccessMethodError as error:
-        message_display.failure(
-            f"The request to return information for file '{file_id}' "
-            + "did not return an S3 access method."
-        )
         output_file_ongoing.unlink()
         raise error
 
@@ -346,9 +318,6 @@ def get_wps_token(max_tries: int, message_display: AbstractMessageDisplay) -> Li
             )
             continue
         return work_package_parts
-    message_display.failure(
-        f"Tried {max_tries} times to parse the work package string and failed."
-    )
     raise exceptions.InvalidWorkPackageToken(tries=max_tries)
 
 


### PR DESCRIPTION
Created a function to replace sys.excepthook that shows the message of an error with the CLIMessageDisplay while hiding traceback (this is only when --debug is not enabled). In most cases, we would print out an error message right before raising an error, and the two messages would be very similar if not identical. I removed the lines for message_display.failure(...) in all the cases where it seemed redundant. In the case that the two messages were complimentary, I left them as is (let me know if you don't like that).