### PR TITLE
Fix endpoint for getting envelopes

### DIFF
--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -189,6 +189,7 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
         dcs_api_url=dcs_api_url,
         package_id=work_package_id,
         my_private_key=my_private_key,
+        my_public_key=my_public_key,
     )
     file_ids_with_extension = work_package_accessor.get_package_files()
 
@@ -218,7 +219,6 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
                 max_wait_time=CONFIG.max_wait_time,
                 part_size=CONFIG.part_size,
                 message_display=message_display,
-                my_public_key=my_public_key,
                 work_package_accessor=work_package_accessor,
             )
         file_stager.update_staged_files()

--- a/ghga_connector/core/api_calls/download.py
+++ b/ghga_connector/core/api_calls/download.py
@@ -22,7 +22,6 @@ from time import sleep
 from typing import Iterator, Tuple, Union
 
 import httpx
-from ghga_service_commons.utils.crypt import encode_key
 from requests.structures import CaseInsensitiveDict
 
 from ghga_connector.core import exceptions
@@ -169,7 +168,7 @@ def await_download_url(
 
 
 def get_file_header_envelope(
-    file_id: str, public_key: bytes, work_package_accessor: WorkPackageAccessor
+    file_id: str, work_package_accessor: WorkPackageAccessor
 ) -> bytes:
     """
     Perform a RESTful API call to retrieve a file header envelope.
@@ -179,11 +178,8 @@ def get_file_header_envelope(
     # fetch a work order token
     decrypted_token = work_package_accessor.get_work_order_token(file_id=file_id)
 
-    # encode public key in base64 (url-safe)
-    public_key_encoded = encode_key(public_key)
-
     # build url and headers
-    url = f"{work_package_accessor.dcs_api_url}/objects/{file_id}/envelopes/{public_key_encoded}"
+    url = f"{work_package_accessor.dcs_api_url}/objects/{file_id}/envelopes"
 
     headers = CaseInsensitiveDict(
         {

--- a/ghga_connector/core/main.py
+++ b/ghga_connector/core/main.py
@@ -161,7 +161,6 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     part_size: int,
     message_display: AbstractMessageDisplay,
     max_wait_time: int,
-    my_public_key: bytes,
     work_package_accessor: WorkPackageAccessor,
     file_id: str,
     file_extension: str = "",
@@ -200,7 +199,6 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     try:
         envelope = get_file_header_envelope(
             file_id=file_id,
-            public_key=my_public_key,
             work_package_accessor=work_package_accessor,
         )
     except (

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -244,10 +244,10 @@ def drs3_objects(file_id: str, request: httpx.Request):
     )
 
 
-@EndpointsHandler.get("/objects/{file_id}/envelopes/{public_key}")
-def drs3_objects_envelopes(file_id: str, public_key: str):
+@EndpointsHandler.get("/objects/{file_id}/envelopes")
+def drs3_objects_envelopes(file_id: str):
     """
-    Mock for the dcs /objects/{file_id}/envelopes/{public_key} call
+    Mock for the dcs /objects/{file_id}/envelopes call
     """
 
     if file_id in ("downloadable", "big-downloadable"):

--- a/tests/unit/test_api_calls.py
+++ b/tests/unit/test_api_calls.py
@@ -161,7 +161,8 @@ def test_get_wps_file_info(httpx_mock: HTTPXMock):
         api_url="http://127.0.0.1",
         dcs_api_url="",
         package_id=wp_id,
-        my_private_key="",
+        my_private_key=b"",
+        my_public_key=b"",
     )
     response = work_package_accessor.get_package_files()
     assert response == files
@@ -175,7 +176,8 @@ def test_get_wps_file_info(httpx_mock: HTTPXMock):
             api_url="http://127.0.0.1",
             dcs_api_url="",
             package_id=wp_id,
-            my_private_key="",
+            my_private_key=b"",
+            my_public_key=b"",
         )
         response = work_package_accessor.get_package_files()
 
@@ -188,7 +190,8 @@ def test_get_wps_file_info(httpx_mock: HTTPXMock):
             api_url="http://127.0.0.1",
             dcs_api_url="",
             package_id=wp_id,
-            my_private_key="",
+            my_private_key=b"",
+            my_public_key=b"",
         )
         response = work_package_accessor.get_package_files()
 


### PR DESCRIPTION
- The connector used a wrong URLfor the endpoint for gettings envelopes. This endpoint does not have the pub key in the path since it's already passed in the work order token.
  The service level integration tests did not catch the issue because the mock endpoint was wrong, too.
  These are the kind of issues that we could catch via contract testing.
- This PR also adds a check that the public key in the token is the same as the one specified in the command line.
- Otherwise, the public key is actually not needed by the connector. We should consider removing the corresponding command line option. However, it helps to check that the right key pair is used, so maybe it's still useful.