### PR TITLE
Improve and fix decrypt command

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
         name: Verify tag format
         # format must be compatible with semantic versioning
         run: |
-          SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
           if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
             echo "Tag format is valid"
           else

--- a/.static_files
+++ b/.static_files
@@ -16,6 +16,7 @@ scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
 scripts/__init__.py
+scripts/update_all.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:0.3.11
+docker pull ghga/ghga-connector:0.3.12
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:0.3.11 .
+docker build -t ghga/ghga-connector:0.3.12 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -42,7 +42,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-connector:0.3.11 --help
+docker run -p 8080:8080 ghga/ghga-connector:0.3.12 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/ghga_connector/__init__.py
+++ b/ghga_connector/__init__.py
@@ -17,4 +17,4 @@
 CLI - Client to perform up- and download operations to and from a local ghga instance
 """
 
-__version__ = "0.3.11"
+__version__ = "0.3.12"

--- a/ghga_connector/cli.py
+++ b/ghga_connector/cli.py
@@ -136,14 +136,15 @@ def download(  # pylint: disable=too-many-arguments,too-many-locals
     ),
     my_public_key_path: Path = typer.Option(
         "./key.pub",
-        help="The path to a public key from the key pair that was announced when the "
-        + "download token was created. Defaults to key.pub in the current folder.",
+        help="The path to a public key from the Crypt4GH key pair "
+        + "that was announced when the download token was created. "
+        + "Defaults to key.pub in the current folder.",
     ),
     my_private_key_path: Path = typer.Option(
         "./key.sec",
-        help="The path to a private key from the key pair that will be used to decrypt "
-        + "the work package access token and work order token. Defaults to key.sec in "
-        + "the current folder.",
+        help="The path to a private key from the Crypt4GH key pair "
+        + "that was announced when the download token was created. "
+        + "Defaults to key.sec in the current folder.",
     ),
     debug: bool = typer.Option(
         False, help="Set this option in order to view traceback for errors."
@@ -235,11 +236,13 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
     output_dir: Path = typer.Option(
         None,
         help="Optional path to a directory that the decrypted file should be written to. "
-        + "Defaults to current working directory.",
+        + "Defaults to input dir.",
     ),
-    decryption_private_key_path: Path = typer.Option(
-        ...,
-        help="Path to the private key that should be used to decrypt the file.",
+    my_private_key_path: Path = typer.Option(
+        "./key.sec",
+        help="The path to a private key from the Crypt4GH key pair "
+        + "that was announced when the download token was created. "
+        + "Defaults to key.sec in the current folder.",
     ),
     debug: bool = typer.Option(
         False, help="Set this option in order to view traceback for errors."
@@ -256,7 +259,7 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
         raise core.exceptions.DirectoryDoesNotExistError(directory=input_dir)
 
     if not output_dir:
-        output_dir = Path(os.getcwd())
+        output_dir = input_dir
 
     if output_dir.exists() and not output_dir.is_dir():
         raise core.exceptions.OutputPathIsNotDirectory(directory=output_dir)
@@ -276,7 +279,7 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
         file_count += 1
 
         # strip the .c4gh extension for the output file
-        output_file = output_dir / input_file.with_suffix("")
+        output_file = output_dir / input_file.with_suffix("").name
 
         if output_file.exists():
             errors[
@@ -289,7 +292,7 @@ def decrypt(  # noqa: C901 # pylint: disable=too-many-branches
             core.decrypt_file(
                 input_file=input_file,
                 output_file=output_file,
-                decryption_private_key_path=decryption_private_key_path,
+                decryption_private_key_path=my_private_key_path,
             )
         except ValueError as error:
             errors[

--- a/scripts/update_all.py
+++ b/scripts/update_all.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Run all update scripts that are present in the repository in the correct order"""
+
+try:
+    from scripts.update_template_files import main as update_template
+except ImportError:
+    pass
+else:
+    print("Pulling in updates from template repository")
+    update_template()
+
+try:
+    from scripts.update_config_docs import main as update_config
+except ImportError:
+    pass
+else:
+    print("Updating config docs")
+    update_config()
+
+try:
+    from scripts.update_openapi_docs import main as update_openapi
+except ImportError:
+    pass
+else:
+    print("Updating OpenAPI docs")
+    update_openapi()
+
+try:
+    from scripts.update_readme import main as update_readme
+except ImportError:
+    pass
+else:
+    print("Updating README")
+    update_readme()


### PR DESCRIPTION
Improve and fix "decrypt" command:

- The option and default for the private key should be the same as in the "download" command.
- The default output dir can be the same as the input dir since encrypted files have an additional extension. Maybe better than using the working directory. But we can discuss that point.
- This PR also fixes the determination of the output file name (should be derived only form input file name, not from input file path).