### PR TITLE
Fix download for small files

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
         name: Verify tag format
         # format must be compatible with semantic versioning
         run: |
-          SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
           if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
             echo "Tag format is valid"
           else

--- a/.static_files
+++ b/.static_files
@@ -16,6 +16,7 @@ scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
 scripts/__init__.py
+scripts/update_all.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:0.3.11
+docker pull ghga/ghga-connector:0.3.12
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:0.3.11 .
+docker build -t ghga/ghga-connector:0.3.12 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -42,7 +42,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-connector:0.3.11 --help
+docker run -p 8080:8080 ghga/ghga-connector:0.3.12 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/ghga_connector/__init__.py
+++ b/ghga_connector/__init__.py
@@ -17,4 +17,4 @@
 CLI - Client to perform up- and download operations to and from a local ghga instance
 """
 
-__version__ = "0.3.11"
+__version__ = "0.3.12"

--- a/ghga_connector/core/main.py
+++ b/ghga_connector/core/main.py
@@ -239,7 +239,7 @@ def download(  # pylint: disable=too-many-arguments, too-many-locals # noqa: C90
     )
 
 
-def download_parts(
+def download_parts(  # pylint: disable=too-many-locals
     *,
     max_concurrent_downloads: int = 5,
     max_queue_size: int = 10,
@@ -280,14 +280,15 @@ def download_parts(
     # Write the downloaded parts to a file
     with open(output_file, "wb") as file:
         # put envelope in file
-        downloaded_size = len(envelope)
         file.write(envelope)
+        offset = len(envelope)
+        downloaded_size = 0
         while downloaded_size < file_size:
             try:
                 start, part = queue.get(block=False)
             except Empty:
                 continue
-            file.seek(start + len(envelope))
+            file.seek(offset + start)
             file.write(part)
             downloaded_size += len(part)
             queue.task_done()
@@ -296,7 +297,7 @@ def download_parts(
 def get_wps_token(max_tries: int, message_display: AbstractMessageDisplay) -> List[str]:
     """
     Expect the work package id and access token as a colon separated string
-    The user will have to input this manually to avoid it becomming part of the
+    The user will have to input this manually to avoid it becoming part of the
     command line history.
     """
     for _ in range(max_tries):

--- a/ghga_connector/core/message_display.py
+++ b/ghga_connector/core/message_display.py
@@ -42,7 +42,7 @@ class AbstractMessageDisplay(ABC):
 
 class MessageColors(str, enum.Enum):
     """
-    Define commmonly used colors for logging
+    Define commonly used colors for logging
     For a selection of valid colors see click.termui._ansi_colors:
     https://github.com/pallets/click/blob/c96545f6f4ba0eab99de6ec8b4ceb77c9bdb2528/src/click/termui.py#L30
     """

--- a/scripts/update_all.py
+++ b/scripts/update_all.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Run all update scripts that are present in the repository in the correct order"""
+
+try:
+    from scripts.update_template_files import main as update_template
+except ImportError:
+    pass
+else:
+    print("Pulling in updates from template repository")
+    update_template()
+
+try:
+    from scripts.update_config_docs import main as update_config
+except ImportError:
+    pass
+else:
+    print("Updating config docs")
+    update_config()
+
+try:
+    from scripts.update_openapi_docs import main as update_openapi
+except ImportError:
+    pass
+else:
+    print("Updating OpenAPI docs")
+    update_openapi()
+
+try:
+    from scripts.update_readme import main as update_readme
+except ImportError:
+    pass
+else:
+    print("Updating README")
+    update_readme()

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -28,7 +28,7 @@ DEFAULT_TEST_CONFIG = Config(
 
 
 def get_test_config(**kwargs):
-    """Get test config params with the defaults being overwritting by the parameter
+    """Get test config params with the defaults being overwritten by the parameter
     passed as kwargs.
     """
 

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -16,6 +16,7 @@
 """Fixtures for testing the storage DAO"""
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import AsyncGenerator, List
 
 import pytest_asyncio
@@ -158,8 +159,9 @@ async def get_big_s3_object(
     the provided s3 storage.
     """
     with big_temp_file(object_size) as big_file:
+        file_path = Path(big_file.name)
         object_fixture = FileObject(
-            file_path=big_file.name,
+            file_path=file_path,
             bucket_id=s3.existing_buckets[0],
             object_id="big-downloadable",
         )
@@ -174,7 +176,7 @@ async def get_big_s3_object(
         )
         upload_file(
             presigned_url=presigned_url,
-            file_path=big_file.name,
+            file_path=file_path,
             file_md5=object_fixture.md5,
         )
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -58,7 +58,7 @@ unintercepted_hosts: list[str] = []
 
 @pytest.fixture
 def non_mocked_hosts() -> list:
-    """Hosts that shall not be mocked by"""
+    """Hosts that shall not be mocked by httpx."""
     # Let requests go out to localstack/S3.
     return unintercepted_hosts
 

--- a/tests/integration/test_file_operations.py
+++ b/tests/integration/test_file_operations.py
@@ -57,7 +57,7 @@ async def test_download_content_range(
 
     queue: Queue = Queue(maxsize=10)
 
-    # donwload content range with dedicated function:
+    # download content range with dedicated function:
     download_content_range(download_url=download_url, start=start, end=end, queue=queue)
 
     obtained_start, obtained_bytes = queue.get()
@@ -105,7 +105,7 @@ async def test_download_file_parts(
         "max_concurrent_downloads": 5,
     }
 
-    # donwload file parts with dedicated function:
+    # download file parts with dedicated function:
     download_file_parts(**kwargs)
 
     obtained = 0


### PR DESCRIPTION
Very mall files could not be fully downloaded, because the download files size was not calculated correctly in the `download_parts` method - the header must not be included.

This PR adds a fix and some more testscases as regression tests. It also includes some clean-up and minor fixes.

