### PR TITLE
Adjust health check function and its default timeout

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_connector"
-version = "1.4.0"
+version = "1.4.1"
 description = "GHGA Connector - A CLI client application for interacting with the GHGA system."
 dependencies = [
     "typer~=0.12",

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:1.4.0
+docker pull ghga/ghga-connector:1.4.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:1.4.0 .
+docker build -t ghga/ghga-connector:1.4.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -40,7 +40,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-connector:1.4.0 --help
+docker run -p 8080:8080 ghga/ghga-connector:1.4.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_connector"
-version = "1.4.0"
+version = "1.4.1"
 description = "GHGA Connector - A CLI client application for interacting with the GHGA system."
 dependencies = [
     "typer~=0.12",

--- a/src/ghga_connector/core/api_calls/__init__.py
+++ b/src/ghga_connector/core/api_calls/__init__.py
@@ -17,6 +17,6 @@
 This sub-package contains the api calls, this service makes for various purposes
 """
 
-from .utils import check_url  # noqa: F401
+from .utils import is_service_healthy  # noqa: F401
 from .well_knowns import WKVSCaller  # noqa: F401
 from .work_package import WorkPackageAccessor  # noqa: F401

--- a/src/ghga_connector/core/api_calls/utils.py
+++ b/src/ghga_connector/core/api_calls/utils.py
@@ -18,10 +18,21 @@
 import httpx
 
 
-def check_url(api_url, *, wait_time=1) -> bool:
+def is_service_healthy(api_url: str, *, timeout_in_seconds: int = 5) -> bool:
+    """Check if the corresponding health endpoint is available"""
+    # Adjust url so the the health endpoint is actually called
+    if not api_url.endswith("/health"):
+        if not api_url.endswith("/"):
+            api_url += "/"
+        api_url += "health"
+
+    return check_url(api_url=api_url, timeout_in_seconds=timeout_in_seconds)
+
+
+def check_url(api_url: str, *, timeout_in_seconds: int = 5) -> bool:
     """Checks, if an url is reachable within a certain time"""
     try:
-        httpx.get(url=api_url, timeout=wait_time)
+        httpx.get(url=api_url, timeout=timeout_in_seconds)
     except httpx.RequestError:
         return False
     return True

--- a/src/ghga_connector/core/downloading/batch_processing.py
+++ b/src/ghga_connector/core/downloading/batch_processing.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from time import sleep
 
 from ghga_connector.core import exceptions
-from ghga_connector.core.api_calls import WorkPackageAccessor, check_url
+from ghga_connector.core.api_calls import WorkPackageAccessor, is_service_healthy
 from ghga_connector.core.client import httpx_client
 from ghga_connector.core.downloading.api_calls import (
     URLResponse,
@@ -148,7 +148,7 @@ class StagingParameters:
 
     def check_api_available(self):
         """Get response from endpoint, else throw corresponding exception"""
-        if not check_url(self.api_url):
+        if not is_service_healthy(self.api_url):
             raise exceptions.ApiNotReachableError(api_url=self.api_url)
 
     def get_file_ids(self) -> list[str]:

--- a/src/ghga_connector/core/main.py
+++ b/src/ghga_connector/core/main.py
@@ -19,7 +19,7 @@
 from pathlib import Path
 
 from ghga_connector.core import exceptions
-from ghga_connector.core.api_calls import WorkPackageAccessor, check_url
+from ghga_connector.core.api_calls import WorkPackageAccessor, is_service_healthy
 from ghga_connector.core.client import async_client, httpx_client
 from ghga_connector.core.crypt import Crypt4GHDecryptor
 from ghga_connector.core.downloading import Downloader, run_download
@@ -54,7 +54,7 @@ async def upload(  # noqa: PLR0913
     if is_file_encrypted(file_path):
         raise exceptions.FileAlreadyEncryptedError(file_path=file_path)
 
-    if not check_url(api_url):
+    if not is_service_healthy(api_url):
         raise exceptions.ApiNotReachableError(api_url=api_url)
 
     async with async_client() as client:
@@ -106,7 +106,7 @@ def download(  # noqa: PLR0913
     file_extension: str = "",
 ) -> None:
     """Core command to download a file. Can be called by CLI, GUI, etc."""
-    if not check_url(api_url):
+    if not is_service_healthy(api_url):
         raise exceptions.ApiNotReachableError(api_url=api_url)
 
     # construct file name with suffix, if given

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -167,8 +167,16 @@ router = MockRouter(
 
 @router.get("/")
 def ready():
-    """Readyness probe."""
+    """Readiness probe."""
     return httpx.Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/health")
+def health():
+    """Used to test if this service is alive"""
+    return httpx.Response(
+        status_code=status.HTTP_200_OK, content=json.dumps({"status": "OK"})
+    )
 
 
 @router.get("/objects/{file_id}")

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -18,15 +18,15 @@
 
 import pytest
 
-from ghga_connector.core.main import check_url
+from ghga_connector.core.api_calls.utils import check_url
 
 
 @pytest.mark.parametrize(
     "api_url,wait_time,expected_response",
     # Google has a higher availability than ghga.de
-    [("https://www.google.de/", 1000, True), ("https://bad_url", 1000, False)],
+    [("https://www.google.de/", 5, True), ("https://bad_url", 5, False)],
 )
-def test_check_url(api_url: str, wait_time: int, expected_response: bool):
+def test_check_url(api_url: str, timeout_in_seconds: int, expected_response: bool):
     """Test the check_url function"""
-    response = check_url(api_url, wait_time=wait_time)
+    response = check_url(api_url, timeout_in_seconds=timeout_in_seconds)
     assert response == expected_response


### PR DESCRIPTION
Health check now always appends "/health" to the provided URL if not present + expects a 200 response with `{"status": "OK"}`