### PR TITLE
Improve file stager

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_connector"
-version = "1.4.1"
+version = "1.4.2"
 description = "GHGA Connector - A CLI client application for interacting with the GHGA system."
 dependencies = [
     "typer~=0.12",

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:1.4.1
+docker pull ghga/ghga-connector:1.4.2
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:1.4.1 .
+docker build -t ghga/ghga-connector:1.4.2 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -40,7 +40,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/ghga-connector:1.4.1 --help
+docker run -p 8080:8080 ghga/ghga-connector:1.4.2 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_connector"
-version = "1.4.1"
+version = "1.4.2"
 description = "GHGA Connector - A CLI client application for interacting with the GHGA system."
 dependencies = [
     "typer~=0.12",

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -154,7 +154,7 @@ def retrieve_download_parameters(
 def get_work_package_information(
     my_private_key: bytes, message_display: core.AbstractMessageDisplay
 ):
-    """Fetch a work packge id and work package token and decrypt the token"""
+    """Fetch a work package id and work package token and decrypt the token"""
     # get work package access token and id from user input
     work_package_id, work_package_token = core.get_wps_token(
         max_tries=3, message_display=message_display
@@ -163,32 +163,6 @@ def get_work_package_information(
     return WorkPackageInformation(
         decrypted_token=decrypted_token, package_id=work_package_id
     )
-
-
-def init_file_stager(
-    *,
-    dcs_api_url: str,
-    file_ids_with_extension: dict[str, str],
-    message_display: CLIMessageDisplay,
-    output_dir: Path,
-    work_package_accessor: core.WorkPackageAccessor,
-) -> core.FileStager:
-    """Initialize file stager for download"""
-    io_handler = core.CliIoHandler()
-    staging_parameters = core.StagingParameters(
-        api_url=dcs_api_url,
-        file_ids_with_extension=file_ids_with_extension,
-        max_wait_time=CONFIG.max_wait_time,
-    )
-
-    file_stager = core.FileStager(
-        message_display=message_display,
-        io_handler=io_handler,
-        staging_parameters=staging_parameters,
-        work_package_accessor=work_package_accessor,
-    )
-    file_stager.check_and_stage(output_dir=output_dir)
-    return file_stager
 
 
 cli = typer.Typer(no_args_is_help=True)
@@ -282,15 +256,16 @@ def download(
         work_package_information=work_package_information,
     )
 
-    file_stager = init_file_stager(
+    stager = core.FileStager(
+        wanted_file_ids=list(parameters.file_ids_with_extension),
         dcs_api_url=parameters.dcs_api_url,
-        file_ids_with_extension=parameters.file_ids_with_extension,
-        message_display=message_display,
         output_dir=output_dir,
+        max_wait_time=CONFIG.max_wait_time,
+        message_display=message_display,
         work_package_accessor=parameters.work_package_accessor,
     )
-    while file_stager.file_ids_remain():
-        for file_id in file_stager.get_staged():
+    while not stager.finished:
+        for file_id in stager.get_staged_files():
             message_display.display(f"Downloading file with id '{file_id}'...")
             core.download(
                 api_url=parameters.dcs_api_url,
@@ -302,7 +277,6 @@ def download(
                 message_display=message_display,
                 work_package_accessor=parameters.work_package_accessor,
             )
-        file_stager.update_staged_files()
 
 
 @cli.command(no_args_is_help=True)

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -265,7 +265,8 @@ def download(
         work_package_accessor=parameters.work_package_accessor,
     )
     while not stager.finished:
-        for file_id in stager.get_staged_files():
+        staged_files = stager.get_staged_files()
+        for file_id in staged_files:
             message_display.display(f"Downloading file with id '{file_id}'...")
             core.download(
                 api_url=parameters.dcs_api_url,
@@ -277,6 +278,7 @@ def download(
                 message_display=message_display,
                 work_package_accessor=parameters.work_package_accessor,
             )
+        staged_files.clear()
 
 
 @cli.command(no_args_is_help=True)

--- a/src/ghga_connector/core/__init__.py
+++ b/src/ghga_connector/core/__init__.py
@@ -30,7 +30,6 @@ from .constants import (  # noqa: F401
 from .downloading.batch_processing import (  # noqa: F401
     CliIoHandler,
     FileStager,
-    StagingParameters,
 )
 from .main import decrypt_file, download, get_wps_token, upload  # noqa: F401
 from .message_display import AbstractMessageDisplay, MessageColors  # noqa: F401

--- a/src/ghga_connector/core/downloading/batch_processing.py
+++ b/src/ghga_connector/core/downloading/batch_processing.py
@@ -232,5 +232,5 @@ class FileStager:
         response = self.io_handler.get_input(message=unknown_ids_present)
         self.io_handler.handle_response(response=response)
         self.message_display.display("Downloading remaining files")
-        self.start_time = time()
+        self.time_started = time()  # reset the timer
         return True


### PR DESCRIPTION
For batch downloading, the connector used a class `FileStager` together with helper classes `StagingParameters` and `StagingState` and a helper function `init_file_stager`.

The PR simplifies this setup by slimming down FileStager to its essentials and removing the helper classes and function.

Also, the batch downloader did not heed the retry-after value suggested by the download controller, but used its own fixed value of 60s. However, it also did not always wait that long between retries, depending on how many files were staged in the first run. If no files were staged, staging requests for the same file were made two times consecutively without waiting.

The PR improves this behavior by waiting as long as specified by the download controller and keeping track of when files were staged last time individually. Since less code is involved, the code should also be easier to understand and maintain. Note that the batch downloader is not tested other than via the archive test bed.