### PR TITLE
Bump setuptools version in Dockerfile

### DIFF
--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69"]
+requires = ["setuptools>=80.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,7 +10,7 @@ authors = [
 requires-python = ">=3.9"
 license = { text = "Apache 2.0" }
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 5 - Production/Stable",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -40,6 +40,7 @@ fixable = [
     "UP", # e.g. List -> list
     "I", # sort imports
     "D", # pydocstyle
+    "RUF022", # sort items in __all__
 ]
 ignore = [
     "E111", # indentation with invalid multiple (for formatter)
@@ -59,6 +60,7 @@ ignore = [
     "D206", # indent-with-spaces (for formatter)
     "D300", # triple-single-quotes (for formatter)
     "UP040", # type statement (not yet supported by mypy)
+    "PLC0206", # Extracting value from dictionary without calling `.items()`
 ]
 select = [
     "C90", # McCabe Complexity
@@ -99,8 +101,9 @@ check_untyped_defs = true
 no_site_packages = false
 
 [tool.pytest.ini_options]
-minversion = "8.0"
+minversion = "8.3"
 asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.paths]
 source = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apk add build-base gcc g++ libffi-dev zlib-dev
 RUN apk upgrade --available
 WORKDIR /service
 COPY --from=builder /service/lock/requirements.txt /service
-RUN pip install --no-deps -r requirements.txt
+RUN pip install -U "setuptools>=80.3" && pip install --no-deps -r requirements.txt
 
 # RUNNER: a container to run the service
 FROM base AS runner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=69",
+    "setuptools>=80.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -11,7 +11,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 5 - Production/Stable",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -69,6 +69,7 @@ fixable = [
     "UP",
     "I",
     "D",
+    "RUF022",
 ]
 ignore = [
     "E111",
@@ -88,6 +89,7 @@ ignore = [
     "D206",
     "D300",
     "UP040",
+    "PLC0206",
 ]
 select = [
     "C90",
@@ -147,8 +149,9 @@ check_untyped_defs = true
 no_site_packages = false
 
 [tool.pytest.ini_options]
-minversion = "8.0"
+minversion = "8.3"
 asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.paths]
 source = [


### PR DESCRIPTION
The setuptools version included by default in the Dockerfile is not in sync with the repo, outdated and triggers Trivy.
Need explicit pip update to get a current setuptools version for now.
Also reverted the python bound mistakenly bumped by updating the template...