### PR TITLE
Handle 400s (GSI-2354)

### DIFF
--- a/src/ghga_connector/core/uploading/api_calls.py
+++ b/src/ghga_connector/core/uploading/api_calls.py
@@ -363,6 +363,8 @@ def _handle_400(*, exception_id: str, work_package_id: UUID4):
             raise exceptions.ChecksumMismatchError()
         case "invalidPartSize":
             raise exceptions.InvalidPartSize()
+        case "uploadSizeMismatch":
+            raise exceptions.UploadSizeMismatchError()
 
 
 def _handle_404(

--- a/src/ghga_connector/core/uploading/api_calls.py
+++ b/src/ghga_connector/core/uploading/api_calls.py
@@ -361,6 +361,8 @@ def _handle_400(*, exception_id: str, work_package_id: UUID4):
             raise exceptions.S3StorageError(work_package_id=work_package_id)
         case "checksumMismatch":
             raise exceptions.ChecksumMismatchError()
+        case "invalidPartSize":
+            raise exceptions.InvalidPartSize()
 
 
 def _handle_404(

--- a/src/ghga_connector/exceptions.py
+++ b/src/ghga_connector/exceptions.py
@@ -544,6 +544,17 @@ class UploadNotRegisteredError(RuntimeError):
         super().__init__(message)
 
 
+class UploadSizeMismatchError(RuntimeError):
+    """Raised when the size of the uploaded file doesn't match the declared size."""
+
+    def __init__(self):
+        msg = (
+            "The size of the uploaded file does not match the size declared when the"
+            " upload was initiated."
+        )
+        super().__init__(msg)
+
+
 class WellKnownValueNotFound(RuntimeError):
     """
     Thrown when a 404 is returned from a call to the well-known-value-service for a

--- a/src/ghga_connector/exceptions.py
+++ b/src/ghga_connector/exceptions.py
@@ -222,6 +222,17 @@ class InvalidFileUploadError(RuntimeError):
         super().__init__(msg)
 
 
+class InvalidPartSize(RuntimeError):
+    """Raised when the server rejects the upload initialization due to an invalid part size."""
+
+    def __init__(self):
+        message = (
+            "The file upload could not be initialized because an acceptable part size"
+            " could not be determined."
+        )
+        super().__init__(message)
+
+
 class InvalidWorkPackageToken(RuntimeError):
     """Thrown when the work package string pasted by the user could not be parsed"""
 

--- a/tests/unit/test_upload_client.py
+++ b/tests/unit/test_upload_client.py
@@ -260,6 +260,15 @@ async def test_delete_file(upload_client: UploadClient, httpx_mock: HTTPXMock):
             FILE_ID,
             exceptions.InvalidPartSize,
         ),
+        # 400 status code - uploadSizeMismatch
+        (
+            400,
+            {"exception_id": "uploadSizeMismatch"},
+            TEST_FUB_ID,
+            FILE_ALIAS,
+            FILE_ID,
+            exceptions.UploadSizeMismatchError,
+        ),
         # 400 status code - no matching exception id
         (
             400,

--- a/tests/unit/test_upload_client.py
+++ b/tests/unit/test_upload_client.py
@@ -251,6 +251,15 @@ async def test_delete_file(upload_client: UploadClient, httpx_mock: HTTPXMock):
             FILE_ID,
             exceptions.ChecksumMismatchError,
         ),
+        # 400 status code - invalidPartSize
+        (
+            400,
+            {"exception_id": "invalidPartSize"},
+            TEST_FUB_ID,
+            FILE_ALIAS,
+            FILE_ID,
+            exceptions.InvalidPartSize,
+        ),
         # 400 status code - no matching exception id
         (
             400,


### PR DESCRIPTION
This adds basic handling for two new 400 response code varieties:
- invalidPartSize, occurs during upload creation
- uploadSizeMismatch, occurs during upload completion