### PR TITLE
TSV-file-driven batch upload (GSI-2443)

### DIFF
--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -70,8 +70,8 @@ def batch_upload(  # noqa: PLR0913
     shorten_names: bool = typer.Option(
         False,
         "--shorten-names",
-        help="Shorten very long aliases and file paths in the output, keeping the start"
-        + " and end (e.g. '/data/run … /final.bam'). Full names are shown by default."
+        help="Shorten very long file aliases in the output, keeping the start and end"
+        + " (e.g. 'sample-001 … -run5.bam'). Full aliases are shown by default."
         + " This is only for improving readability and does not affect how"
         + " data is sent to GHGA.",
     ),

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -67,6 +67,14 @@ def batch_upload(  # noqa: PLR0913
         help="List the files that would be uploaded (after skipping any already in the"
         + " upload box) without uploading anything.",
     ),
+    shorten_names: bool = typer.Option(
+        False,
+        "--shorten-names",
+        help="Shorten very long aliases and file paths in the output, keeping the start"
+        + " and end (e.g. '/data/run … /final.bam'). Full names are shown by default."
+        + " This is only for improving readability and does not affect how"
+        + " data is sent to GHGA.",
+    ),
     debug: bool = typer.Option(
         False, help="Set this option in order to view traceback for errors."
     ),
@@ -85,6 +93,7 @@ def batch_upload(  # noqa: PLR0913
             passphrase=passphrase,
             max_retries=max_retries,
             dry_run=dry_run,
+            shorten=shorten_names,
         )
     )
 

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -40,7 +40,9 @@ def batch_upload(  # noqa: PLR0913
         ...,
         help=(
             "Path to a TSV file describing the files to upload. The first column must"
-            + " contain the file path and the second column the file alias."
+            + " contain the file path and the second column the file alias. Relative"
+            + " file paths can only be used if this command is run from same directory."
+            + " Prefer to use absolute paths."
         ),
     ),
     my_public_key_path: Path = typer.Option(

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import typer
 
 from ghga_connector import exceptions
-from ghga_connector.constants import C4GH, MAX_RETRIES
+from ghga_connector.constants import C4GH, DEFAULT_BATCH_MAX_RETRIES
 from ghga_connector.core import CLIMessageDisplay
 from ghga_connector.core.main import (
     async_batch_upload,
@@ -59,7 +59,7 @@ def batch_upload(  # noqa: PLR0913
         + "Only needs to be provided if the key is actually encrypted.",
     ),
     max_retries: int = typer.Option(
-        MAX_RETRIES,
+        DEFAULT_BATCH_MAX_RETRIES,
         help="Maximum number of automatic retries for files that fail to upload.",
     ),
     dry_run: bool = typer.Option(

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -16,35 +16,31 @@
 """CLI-specific wrappers around core functions."""
 
 import asyncio
-import os
 from pathlib import Path
 
 import typer
 
 from ghga_connector import exceptions
-from ghga_connector.constants import C4GH
+from ghga_connector.constants import C4GH, MAX_RETRIES
 from ghga_connector.core import CLIMessageDisplay
 from ghga_connector.core.main import (
+    async_batch_upload,
     async_download,
     async_ubox,
-    async_upload,
     decrypt_file,
 )
-from ghga_connector.core.utils import modify_for_debug, strtobool
+from ghga_connector.core.utils import modify_for_debug
 
 cli = typer.Typer(no_args_is_help=True)
 
 
-@cli.command(no_args_is_help=True)
-def upload(
-    file_info: list[str] = typer.Argument(
+@cli.command(name="batch-upload", no_args_is_help=True)
+def batch_upload(  # noqa: PLR0913
+    tsv: Path = typer.Option(
         ...,
         help=(
-            "The comma-separated file alias and path. If only a file path is supplied"
-            + " then the file name will be used instead. Example:"
-            + " 'my_file,./files/abc.bam' or './files/abc.bam' (in the latter, the file"
-            + " alias would be 'abc.bam'). Specify as many files as needed, e.g.:"
-            + " 'ghga-connector upload alias1,file1.bam file2.bam alias3,file3.bam ...'"
+            "Path to a TSV file describing the files to upload. The first column must"
+            + " contain the file path and the second column the file alias."
         ),
     ),
     my_public_key_path: Path = typer.Option(
@@ -62,24 +58,35 @@ def upload(
         help="Passphrase for the encrypted private key. "
         + "Only needs to be provided if the key is actually encrypted.",
     ),
+    max_retries: int = typer.Option(
+        MAX_RETRIES,
+        help="Maximum number of automatic retries for files that fail to upload.",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        help="List the files that would be uploaded (after skipping any already in the"
+        + " upload box) without uploading anything.",
+    ),
     debug: bool = typer.Option(
         False, help="Set this option in order to view traceback for errors."
     ),
 ):
-    """Upload one or more files asynchronously"""
+    """Upload a batch of files described by a TSV file.
+
+    Files already present in the upload box are skipped, so the command can be re-run
+    to resume an interrupted batch. Files that fail to upload are retried automatically.
+    """
     modify_for_debug(debug)
     asyncio.run(
-        async_upload(
-            unparsed_file_info=file_info,
+        async_batch_upload(
+            tsv=tsv,
             my_public_key_path=my_public_key_path,
             my_private_key_path=my_private_key_path,
             passphrase=passphrase,
+            max_retries=max_retries,
+            dry_run=dry_run,
         )
     )
-
-
-if strtobool(os.getenv("UPLOAD_ENABLED") or "false"):
-    cli.command(no_args_is_help=True)(upload)
 
 
 @cli.command()

--- a/src/ghga_connector/constants.py
+++ b/src/ghga_connector/constants.py
@@ -24,10 +24,15 @@ DEFAULT_PART_SIZE = 64 * (1024**2)  # 64 MiB
 TIMEOUT = 60.0
 TIMEOUT_LONG = 5 * TIMEOUT + 10
 MAX_PART_NUMBER = 10000
-MAX_RETRIES = 5
+MAX_RETRIES = 5  # retries for a single file part at the HTTP layer (see uploader.py)
 MAX_WAIT_TIME = 60 * 60
 MAX_UPLOAD_BACKOFF_SEC = 360
 UPLOAD_RETRY_BACKOFF_SEC = 5
+# Batch upload: how many times a failed file is retried, and how long to wait between
+#  retry passes. Kept separate from the part-level retry constants above so the two can
+#  be tuned independently.
+DEFAULT_BATCH_MAX_RETRIES = 3
+BATCH_RETRY_BACKOFF_SEC = 5
 C4GH = ".c4gh"
 CACHE_MIN_FRESH = 3
 DOWNLOAD_URL_LIFESPAN = 60  # 1 minute

--- a/src/ghga_connector/core/main.py
+++ b/src/ghga_connector/core/main.py
@@ -61,6 +61,9 @@ async def async_batch_upload(  # noqa: PLR0913
     files that fail to upload are retried up to `max_retries` times. If `dry_run` is
     True, the files that would be uploaded are listed but no uploads are performed. If
     `shorten` is set, long aliases are middle-elided in the output.
+
+    A note on file paths: Relative file paths interpreted in the context of the current
+    working directory when the batch upload command is executed.
     """
     core_file_info_list = load_file_info_from_tsv(tsv)
     async with async_client() as client, set_runtime_config(client=client):

--- a/src/ghga_connector/core/main.py
+++ b/src/ghga_connector/core/main.py
@@ -60,7 +60,7 @@ async def async_batch_upload(  # noqa: PLR0913
     in the second column. Files already present in the upload box are skipped and any
     files that fail to upload are retried up to `max_retries` times. If `dry_run` is
     True, the files that would be uploaded are listed but no uploads are performed. If
-    `shorten` is set, long aliases and paths are middle-elided in the output.
+    `shorten` is set, long aliases are middle-elided in the output.
     """
     core_file_info_list = load_file_info_from_tsv(tsv)
     async with async_client() as client, set_runtime_config(client=client):
@@ -91,8 +91,8 @@ async def upload_files(  # noqa: PLR0913
 
     Files already present in the upload box are skipped and failures are retried up to
     `max_retries` times. If `dry_run` is True, the files that would be uploaded are
-    listed but no uploads are performed. If `shorten` is set, long aliases and paths
-    are middle-elided in the output.
+    listed but no uploads are performed. If `shorten` is set, long aliases are
+    middle-elided in the output.
     """
     my_public_key = utils.get_public_key(my_public_key_path)
     my_private_key = utils.get_private_key(my_private_key_path, passphrase)

--- a/src/ghga_connector/core/main.py
+++ b/src/ghga_connector/core/main.py
@@ -52,13 +52,15 @@ async def async_batch_upload(  # noqa: PLR0913
     passphrase: str | None = None,
     max_retries: int = DEFAULT_BATCH_MAX_RETRIES,
     dry_run: bool = False,
+    shorten: bool = False,
 ):
     """Upload a batch of files described by a TSV file asynchronously.
 
     The TSV is expected to have the file path in the first column and the file alias
     in the second column. Files already present in the upload box are skipped and any
     files that fail to upload are retried up to `max_retries` times. If `dry_run` is
-    True, the files that would be uploaded are listed but no uploads are performed.
+    True, the files that would be uploaded are listed but no uploads are performed. If
+    `shorten` is set, long aliases and paths are middle-elided in the output.
     """
     core_file_info_list = load_file_info_from_tsv(tsv)
     async with async_client() as client, set_runtime_config(client=client):
@@ -70,6 +72,7 @@ async def async_batch_upload(  # noqa: PLR0913
             passphrase=passphrase,
             max_retries=max_retries,
             dry_run=dry_run,
+            shorten=shorten,
         )
 
 
@@ -82,12 +85,14 @@ async def upload_files(  # noqa: PLR0913
     passphrase: str | None = None,
     max_retries: int = DEFAULT_BATCH_MAX_RETRIES,
     dry_run: bool = False,
+    shorten: bool = False,
 ) -> None:
     """Core command to upload a batch of files. Can be called by CLI, GUI, etc.
 
     Files already present in the upload box are skipped and failures are retried up to
     `max_retries` times. If `dry_run` is True, the files that would be uploaded are
-    listed but no uploads are performed.
+    listed but no uploads are performed. If `shorten` is set, long aliases and paths
+    are middle-elided in the output.
     """
     my_public_key = utils.get_public_key(my_public_key_path)
     my_private_key = utils.get_private_key(my_private_key_path, passphrase)
@@ -110,6 +115,7 @@ async def upload_files(  # noqa: PLR0913
         max_concurrent_uploads=config.max_concurrent_uploads,
         max_retries=max_retries,
         dry_run=dry_run,
+        shorten=shorten,
     )
 
 

--- a/src/ghga_connector/core/main.py
+++ b/src/ghga_connector/core/main.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import httpx
 
 from ghga_connector.config import get_config, set_runtime_config
+from ghga_connector.constants import MAX_RETRIES
 from ghga_connector.core.client import async_client
 from ghga_connector.core.downloading.api_calls import DownloadClient
 from ghga_connector.core.downloading.batch_processing import FileStager
@@ -30,8 +31,8 @@ from ghga_connector.core.downloading.downloader import (
 )
 from ghga_connector.core.uploading.api_calls import UploadClient
 from ghga_connector.core.uploading.batch_processing import (
-    parse_file_info_for_upload,
-    upload_files_from_list,
+    load_file_info_from_tsv,
+    run_batch_upload,
 )
 from ghga_connector.core.uploading.structs import CoreFileInfo, FileInfoForUpload
 from ghga_connector.core.uploading.ubox_shell import UboxShell
@@ -43,34 +44,51 @@ from .crypt import Crypt4GHDecryptor
 from .message_display import CLIMessageDisplay
 
 
-async def async_upload(
+async def async_batch_upload(  # noqa: PLR0913
     *,
-    unparsed_file_info: list[str],
+    tsv: Path,
     my_public_key_path: Path,
     my_private_key_path: Path,
     passphrase: str | None = None,
+    max_retries: int = MAX_RETRIES,
+    dry_run: bool = False,
 ):
-    """Upload one or more files asynchronously"""
-    parsed_file_info = parse_file_info_for_upload(unparsed_file_info)
+    """Upload a batch of files described by a TSV file asynchronously.
+
+    The TSV is expected to have the file path in the first column and the file alias
+    in the second column. Files already present in the upload box are skipped and any
+    files that fail to upload are retried up to `max_retries` times. If `dry_run` is
+    True, the files that would be uploaded are listed but no uploads are performed.
+    """
+    core_file_info_list = load_file_info_from_tsv(tsv)
     async with async_client() as client, set_runtime_config(client=client):
         await upload_files(
             client=client,
-            core_file_info_list=parsed_file_info,
+            core_file_info_list=core_file_info_list,
             my_public_key_path=my_public_key_path,
             my_private_key_path=my_private_key_path,
             passphrase=passphrase,
+            max_retries=max_retries,
+            dry_run=dry_run,
         )
 
 
-async def upload_files(
+async def upload_files(  # noqa: PLR0913
     *,
     client: httpx.AsyncClient,
     core_file_info_list: list[CoreFileInfo],
     my_public_key_path: Path,
     my_private_key_path: Path,
     passphrase: str | None = None,
+    max_retries: int = MAX_RETRIES,
+    dry_run: bool = False,
 ) -> None:
-    """Core command to upload one or more files. Can be called by CLI, GUI, etc."""
+    """Core command to upload a batch of files. Can be called by CLI, GUI, etc.
+
+    Files already present in the upload box are skipped and failures are retried up to
+    `max_retries` times. If `dry_run` is True, the files that would be uploaded are
+    listed but no uploads are performed.
+    """
     my_public_key = utils.get_public_key(my_public_key_path)
     my_private_key = utils.get_private_key(my_private_key_path, passphrase)
     work_package_client = WorkPackageClient(
@@ -86,11 +104,13 @@ async def upload_files(
     ]
 
     CLIMessageDisplay.display(f"Preparing to upload {len(core_file_info_list)} files")
-    await upload_files_from_list(
+    await run_batch_upload(
         upload_client=upload_client,
         file_info_list=full_file_info,
         my_private_key=my_private_key,
         max_concurrent_uploads=config.max_concurrent_uploads,
+        max_retries=max_retries,
+        dry_run=dry_run,
     )
 
 

--- a/src/ghga_connector/core/main.py
+++ b/src/ghga_connector/core/main.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import httpx
 
 from ghga_connector.config import get_config, set_runtime_config
-from ghga_connector.constants import MAX_RETRIES
+from ghga_connector.constants import DEFAULT_BATCH_MAX_RETRIES
 from ghga_connector.core.client import async_client
 from ghga_connector.core.downloading.api_calls import DownloadClient
 from ghga_connector.core.downloading.batch_processing import FileStager
@@ -50,7 +50,7 @@ async def async_batch_upload(  # noqa: PLR0913
     my_public_key_path: Path,
     my_private_key_path: Path,
     passphrase: str | None = None,
-    max_retries: int = MAX_RETRIES,
+    max_retries: int = DEFAULT_BATCH_MAX_RETRIES,
     dry_run: bool = False,
 ):
     """Upload a batch of files described by a TSV file asynchronously.
@@ -80,7 +80,7 @@ async def upload_files(  # noqa: PLR0913
     my_public_key_path: Path,
     my_private_key_path: Path,
     passphrase: str | None = None,
-    max_retries: int = MAX_RETRIES,
+    max_retries: int = DEFAULT_BATCH_MAX_RETRIES,
     dry_run: bool = False,
 ) -> None:
     """Core command to upload a batch of files. Can be called by CLI, GUI, etc.
@@ -103,7 +103,6 @@ async def upload_files(  # noqa: PLR0913
         for cfi in core_file_info_list
     ]
 
-    CLIMessageDisplay.display(f"Preparing to upload {len(core_file_info_list)} files")
     await run_batch_upload(
         upload_client=upload_client,
         file_info_list=full_file_info,

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -268,8 +268,7 @@ async def upload_files_from_list(
                     "Upload process stopped. If applicable, any previously completed"
                     + " file uploads remain uploaded."
                 )
-                # The current file plus any not yet attempted did not upload. Retrying
-                # cannot free space, so mark the pass as halted.
+                # Retrying is futile, so mark the pass as halted.
                 failed.extend(file_info_list[index:])
                 return BatchPassResult(failed=failed, halted=True)
 
@@ -432,8 +431,12 @@ async def run_batch_upload(  # noqa: PLR0913
             return
 
         # A halted pass (box full or user abort) is not retried.
+        # Note: If `halted=True`, the cause is already logged via CLIMessageDisplay
         if result.halted or attempt >= max_retries:
             halted = result.halted
+
+            if attempt >= max_retries:
+                CLIMessageDisplay.failure("All retries exhausted.")
             break
 
         attempt += 1

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -41,6 +41,38 @@ _CANCELLED_STATE = "cancelled"
 #  eliding the rest, so a large resume doesn't print a wall of text.
 _MAX_LISTED_ALIASES = 10
 
+# Names (aliases/paths) longer than this are middle-elided (keeping the start and end)
+#  when name shortening is enabled, so very long paths don't blow out the output.
+_MAX_NAME_WIDTH = 60
+
+# The marker inserted in place of an elided middle, with surrounding spaces so the
+#  break is visually clear.
+_ELLIPSIS = " … "
+
+
+def _elide_middle(text: str, max_len: int = _MAX_NAME_WIDTH) -> str:
+    """Shorten ``text`` to ``max_len`` chars by replacing its middle with an ellipsis.
+
+    The beginning and end are preserved, which keeps the most useful parts of a path
+    (its root and filename) visible. Text already within ``max_len`` is returned
+    unchanged.
+    """
+    if len(text) <= max_len:
+        return text
+    keep = max_len - len(_ELLIPSIS)  # reserve room for the ellipsis marker
+    if keep <= 0:
+        return text[:max_len]
+    head = (keep + 1) // 2
+    tail = keep - head
+    if tail <= 0:
+        return f"{text[:head]}{_ELLIPSIS}"
+    return f"{text[:head]}{_ELLIPSIS}{text[-tail:]}"
+
+
+def _display_name(name: str, *, shorten: bool) -> str:
+    """Return ``name`` middle-elided if ``shorten`` is set, otherwise unchanged."""
+    return _elide_middle(name) if shorten else name
+
 
 def _summarize_aliases(aliases: list[str]) -> str:
     """Render a list of aliases as a comma-separated string, eliding long lists."""
@@ -198,21 +230,28 @@ async def upload_files_from_list(
     file_info_list: list[FileInfoForUpload],
     my_private_key: SecretBytes,
     max_concurrent_uploads: int,
+    shorten: bool = False,
 ) -> BatchPassResult:
     """Upload all files in the provided list of file paths.
 
     If the user cancels the upload, e.g. via CTRL+C, or if an unexpected error occurs,
     the in progress file will be cancelled and the upload process halted.
 
+    If ``shorten`` is set, long aliases are middle-elided in user-facing messages.
+
     Returns a ``BatchPassResult`` describing which files failed and whether the pass was
     halted before all files were attempted.
     """
     failed: list[FileInfoForUpload] = []
     for index, file_info in enumerate(file_info_list):
+        # Display name for user-facing messages and the progress bar; logs and API
+        # calls always use the full alias.
+        display_alias = _display_name(file_info.alias, shorten=shorten)
         uploader = Uploader(
             upload_client=upload_client,
             file_info=file_info,
             max_concurrent_uploads=max_concurrent_uploads,
+            display_name=display_alias,
         )
         log.info("Initializing upload for %s", file_info.alias)
         log.debug("Full file path is %s", str(file_info.path.resolve()))
@@ -256,9 +295,9 @@ async def upload_files_from_list(
         except KeyboardInterrupt:
             # User cancellation is handled here
             CLIMessageDisplay.failure(
-                f"User aborted upload for {file_info.alias}, (file ID {file_id}), deleting."
+                f"User aborted upload for {display_alias}, (file ID {file_id}), deleting."
             )
-            await perform_cleanup(uploader=uploader, alias=file_info.alias)
+            await perform_cleanup(uploader=uploader, alias=display_alias)
             # An explicit user abort stops the whole batch rather than retrying.
             failed.append(file_info)
             failed.extend(file_info_list[index + 1 :])
@@ -267,13 +306,13 @@ async def upload_files_from_list(
             # All other errors are handled here
             CLIMessageDisplay.failure(str(err))
             CLIMessageDisplay.failure(
-                f"Failed to upload {file_info.alias}, (file ID {file_id}), deleting."
+                f"Failed to upload {display_alias}, (file ID {file_id}), deleting."
             )
-            await perform_cleanup(uploader=uploader, alias=file_info.alias)
+            await perform_cleanup(uploader=uploader, alias=display_alias)
             failed.append(file_info)
         else:
             # This is the success case
-            CLIMessageDisplay.success(f"Successfully uploaded {file_info.alias}.")
+            CLIMessageDisplay.success(f"Successfully uploaded {display_alias}.")
 
     return BatchPassResult(failed=failed, halted=False)
 
@@ -292,11 +331,12 @@ async def _already_uploaded_aliases(upload_client: UploadClient) -> set[str]:
     }
 
 
-def _report_dry_run(pending: list[FileInfoForUpload]) -> None:
+def _report_dry_run(pending: list[FileInfoForUpload], *, shorten: bool) -> None:
     """Print the files that would be uploaded, without uploading anything.
 
     The alias, path and size columns are padded to the widest value in each column
-    so they line up vertically for readability.
+    so they line up vertically for readability. If ``shorten`` is set, long aliases
+    and paths are middle-elided.
     """
     total_size = sum(fi.decrypted_size for fi in pending)
     CLIMessageDisplay.display(
@@ -305,7 +345,11 @@ def _report_dry_run(pending: list[FileInfoForUpload]) -> None:
     )
 
     rows = [
-        (fi.alias, str(fi.path), utils.human_readable_size(fi.decrypted_size))
+        (
+            _display_name(fi.alias, shorten=shorten),
+            _display_name(str(fi.path), shorten=shorten),
+            utils.human_readable_size(fi.decrypted_size),
+        )
         for fi in pending
     ]
     # Column widths account for both the values and the header labels.
@@ -335,6 +379,7 @@ async def run_batch_upload(  # noqa: PLR0913
     max_concurrent_uploads: int,
     max_retries: int = DEFAULT_BATCH_MAX_RETRIES,
     dry_run: bool = False,
+    shorten: bool = False,
 ) -> None:
     """Upload a batch of files, skipping those already uploaded and retrying failures.
 
@@ -346,13 +391,15 @@ async def run_batch_upload(  # noqa: PLR0913
     If ``dry_run`` is True, the upload box is still queried so that already-uploaded
     files are reported as skipped, but the files that remain are only listed - no
     uploads are initiated.
+
+    If ``shorten`` is set, long aliases and paths are middle-elided in the output.
     """
     already_uploaded = await _already_uploaded_aliases(upload_client)
     skipped = [fi.alias for fi in file_info_list if fi.alias in already_uploaded]
     if skipped:
         CLIMessageDisplay.display(
             f"Skipping {len(skipped)} file(s) already present in the upload box: "
-            + _summarize_aliases(skipped)
+            + _summarize_aliases([_display_name(a, shorten=shorten) for a in skipped])
         )
 
     pending = [fi for fi in file_info_list if fi.alias not in already_uploaded]
@@ -361,7 +408,7 @@ async def run_batch_upload(  # noqa: PLR0913
         return
 
     if dry_run:
-        _report_dry_run(pending)
+        _report_dry_run(pending, shorten=shorten)
         return
 
     CLIMessageDisplay.display(f"Uploading {len(pending)} file(s)...")
@@ -373,6 +420,7 @@ async def run_batch_upload(  # noqa: PLR0913
             file_info_list=pending,
             my_private_key=my_private_key,
             max_concurrent_uploads=max_concurrent_uploads,
+            shorten=shorten,
         )
         pending = result.failed
 
@@ -394,7 +442,9 @@ async def run_batch_upload(  # noqa: PLR0913
         )
         await asyncio.sleep(BATCH_RETRY_BACKOFF_SEC)
 
-    aliases = _summarize_aliases([fi.alias for fi in pending])
+    aliases = _summarize_aliases(
+        [_display_name(fi.alias, shorten=shorten) for fi in pending]
+    )
     if halted:
         # The stop reason was already reported by upload_files_from_list.
         CLIMessageDisplay.failure(

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -15,6 +15,7 @@
 
 """Batch processing for the upload process"""
 
+import asyncio
 import logging
 import signal
 from dataclasses import dataclass, field
@@ -23,7 +24,7 @@ from pathlib import Path
 from pydantic import SecretBytes
 
 from ghga_connector import exceptions
-from ghga_connector.constants import MAX_RETRIES
+from ghga_connector.constants import BATCH_RETRY_BACKOFF_SEC, DEFAULT_BATCH_MAX_RETRIES
 from ghga_connector.core import CLIMessageDisplay, utils
 from ghga_connector.core.crypt.encryption import Crypt4GHEncryptor
 from ghga_connector.core.uploading.api_calls import UploadClient
@@ -35,6 +36,18 @@ log = logging.getLogger(__name__)
 # The file state, as reported by the Upload API, that marks a cancelled (deleted)
 #  upload. A file in any other state is considered already present in the box.
 _CANCELLED_STATE = "cancelled"
+
+# When listing skipped or failed aliases in a message, show at most this many before
+#  eliding the rest, so a large resume doesn't print a wall of text.
+_MAX_LISTED_ALIASES = 10
+
+
+def _summarize_aliases(aliases: list[str]) -> str:
+    """Render a list of aliases as a comma-separated string, eliding long lists."""
+    if len(aliases) <= _MAX_LISTED_ALIASES:
+        return ", ".join(aliases)
+    shown = ", ".join(aliases[:_MAX_LISTED_ALIASES])
+    return f"{shown}, ... (+{len(aliases) - _MAX_LISTED_ALIASES} more)"
 
 
 def parse_file_info_for_upload(file_info: list[str]) -> list[CoreFileInfo]:
@@ -196,7 +209,6 @@ async def upload_files_from_list(
     Returns a ``BatchPassResult`` describing which files failed and whether the pass was
     halted before all files were attempted.
     """
-    CLIMessageDisplay.display(f"Starting batch upload of {len(file_info_list)} files")
     failed: list[FileInfoForUpload] = []
     for index, file_info in enumerate(file_info_list):
         uploader = Uploader(
@@ -323,14 +335,15 @@ async def run_batch_upload(  # noqa: PLR0913
     file_info_list: list[FileInfoForUpload],
     my_private_key: SecretBytes,
     max_concurrent_uploads: int,
-    max_retries: int = MAX_RETRIES,
+    max_retries: int = DEFAULT_BATCH_MAX_RETRIES,
     dry_run: bool = False,
 ) -> None:
     """Upload a batch of files, skipping those already uploaded and retrying failures.
 
     Files whose alias is already present in the upload box (in any non-cancelled
     state) are skipped, so re-running the command resumes where a previous run left
-    off. Files that fail to upload are retried up to ``max_retries`` times.
+    off. Files that fail to upload are retried up to ``max_retries`` times, waiting
+    ``BATCH_RETRY_BACKOFF_SEC`` seconds between passes.
 
     If ``dry_run`` is True, the upload box is still queried so that already-uploaded
     files are reported as skipped, but the files that remain are only listed - no
@@ -341,7 +354,7 @@ async def run_batch_upload(  # noqa: PLR0913
     if skipped:
         CLIMessageDisplay.display(
             f"Skipping {len(skipped)} file(s) already present in the upload box: "
-            + ", ".join(skipped)
+            + _summarize_aliases(skipped)
         )
 
     pending = [fi for fi in file_info_list if fi.alias not in already_uploaded]
@@ -353,6 +366,7 @@ async def run_batch_upload(  # noqa: PLR0913
         _report_dry_run(pending)
         return
 
+    CLIMessageDisplay.display(f"Uploading {len(pending)} file(s)...")
     attempt = 0
     halted = False
     while True:
@@ -377,10 +391,12 @@ async def run_batch_upload(  # noqa: PLR0913
 
         attempt += 1
         CLIMessageDisplay.display(
-            f"Retrying {len(pending)} failed file(s) (retry {attempt}/{max_retries})..."
+            f"Retrying {len(pending)} failed file(s) in {BATCH_RETRY_BACKOFF_SEC}s"
+            + f" (retry {attempt}/{max_retries})..."
         )
+        await asyncio.sleep(BATCH_RETRY_BACKOFF_SEC)
 
-    aliases = ", ".join(fi.alias for fi in pending)
+    aliases = _summarize_aliases([fi.alias for fi in pending])
     if halted:
         # The stop reason was already reported by upload_files_from_list.
         CLIMessageDisplay.failure(

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -17,11 +17,13 @@
 
 import logging
 import signal
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic import SecretBytes
 
 from ghga_connector import exceptions
+from ghga_connector.constants import MAX_RETRIES
 from ghga_connector.core import CLIMessageDisplay, utils
 from ghga_connector.core.crypt.encryption import Crypt4GHEncryptor
 from ghga_connector.core.uploading.api_calls import UploadClient
@@ -29,6 +31,10 @@ from ghga_connector.core.uploading.structs import CoreFileInfo, FileInfoForUploa
 from ghga_connector.core.uploading.uploader import Uploader
 
 log = logging.getLogger(__name__)
+
+# The file state, as reported by the Upload API, that marks a cancelled (deleted)
+#  upload. A file in any other state is considered already present in the box.
+_CANCELLED_STATE = "cancelled"
 
 
 def parse_file_info_for_upload(file_info: list[str]) -> list[CoreFileInfo]:
@@ -68,6 +74,71 @@ def parse_file_info_for_upload(file_info: list[str]) -> list[CoreFileInfo]:
     return items
 
 
+def load_file_info_from_tsv(tsv_path: Path) -> list[CoreFileInfo]:
+    """Load file alias/path pairs from a TSV file.
+
+    The TSV is expected to contain the file path in the first column and the file
+    alias in the second column, matching the format used by the GHGA Data Steward
+    Kit. Blank lines are ignored, and a final ``decrypted_size`` is derived for each
+    file from disk.
+
+    Raises:
+        FileDoesNotExistError: If the TSV itself, or one of the referenced files,
+            does not exist.
+        RuntimeError: If a non-blank line does not contain both a path and an alias.
+        ValueError: If duplicate aliases or file paths are detected.
+    """
+    if not tsv_path.is_file():
+        raise exceptions.FileDoesNotExistError(file_path=tsv_path)
+
+    items: list[CoreFileInfo] = []
+    with open(tsv_path, encoding="utf-8") as tsv_file:
+        for line_number, raw_line in enumerate(tsv_file, 1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            columns = line.split("\t")
+            if len(columns) < 2:
+                # No tab was found on a non-empty line. The most common cause is a file
+                # that uses spaces rather than tabs, so call that out explicitly.
+                hint = (
+                    " It looks like this line separates the columns with spaces rather"
+                    + " than a tab."
+                    if " " in line
+                    else ""
+                )
+                raise RuntimeError(
+                    f"Line {line_number} of '{tsv_path}' could not be parsed: the file"
+                    + " must be tab-separated, with the file path in the first column"
+                    + f" and the alias in the second.{hint}"
+                )
+            path = columns[0].strip()
+            alias = columns[1].strip()
+            if not path or not alias:
+                raise RuntimeError(
+                    f"Line {line_number} of '{tsv_path}' is missing a file path or"
+                    + " alias. Each non-empty line must have a file path and an alias"
+                    + " separated by a tab."
+                )
+            validated_path = utils.parse_file_upload_path(path)
+            items.append(
+                CoreFileInfo(
+                    alias=alias,
+                    path=validated_path,
+                    decrypted_size=validated_path.stat().st_size,
+                )
+            )
+
+    if not items:
+        raise RuntimeError(f"No file entries were found in '{tsv_path}'.")
+
+    # Ensure unique aliases and file paths
+    for field_name in ["alias", "path"]:
+        utils.detect_duplicates([getattr(x, field_name) for x in items], field_name)
+
+    return items
+
+
 def _signal_handler(signum, frame):
     """Capture KeyboardInterrupt"""
     CLIMessageDisplay.display("Cleanup in progress, please wait…")
@@ -95,20 +166,39 @@ async def perform_cleanup(*, uploader: Uploader, alias: str) -> None:
         )
 
 
+@dataclass
+class BatchPassResult:
+    """The outcome of a single pass over a list of files in a batch upload.
+
+    Attributes:
+        failed: The files that did not upload successfully during this pass.
+        halted: True if the batch was stopped before all files were attempted
+            (e.g. the upload box ran out of space or the user aborted). When set,
+            the caller should not retry, since retrying cannot help.
+    """
+
+    failed: list[FileInfoForUpload] = field(default_factory=list)
+    halted: bool = False
+
+
 async def upload_files_from_list(
     *,
     upload_client: UploadClient,
     file_info_list: list[FileInfoForUpload],
     my_private_key: SecretBytes,
     max_concurrent_uploads: int,
-):
+) -> BatchPassResult:
     """Upload all files in the provided list of file paths.
 
     If the user cancels the upload, e.g. via CTRL+C, or if an unexpected error occurs,
     the in progress file will be cancelled and the upload process halted.
+
+    Returns a ``BatchPassResult`` describing which files failed and whether the pass was
+    halted before all files were attempted.
     """
     CLIMessageDisplay.display(f"Starting batch upload of {len(file_info_list)} files")
-    for file_info in file_info_list:
+    failed: list[FileInfoForUpload] = []
+    for index, file_info in enumerate(file_info_list):
         uploader = Uploader(
             upload_client=upload_client,
             file_info=file_info,
@@ -128,9 +218,13 @@ async def upload_files_from_list(
                     "Upload process stopped. If applicable, any previously completed"
                     + " file uploads remain uploaded."
                 )
-                return
+                # The current file plus any not yet attempted did not upload. Retrying
+                # cannot free space, so mark the pass as halted.
+                failed.extend(file_info_list[index:])
+                return BatchPassResult(failed=failed, halted=True)
 
             # For other errors, go to next file because there's nothing else to do here
+            failed.append(file_info)
             continue
         log.info(
             "File upload successfully initialized for %s."
@@ -155,6 +249,10 @@ async def upload_files_from_list(
                 f"User aborted upload for {file_info.alias}, (file ID {file_id}), deleting."
             )
             await perform_cleanup(uploader=uploader, alias=file_info.alias)
+            # An explicit user abort stops the whole batch rather than retrying.
+            failed.append(file_info)
+            failed.extend(file_info_list[index + 1 :])
+            return BatchPassResult(failed=failed, halted=True)
         except BaseException as err:
             # All other errors are handled here
             CLIMessageDisplay.failure(str(err))
@@ -162,6 +260,135 @@ async def upload_files_from_list(
                 f"Failed to upload {file_info.alias}, (file ID {file_id}), deleting."
             )
             await perform_cleanup(uploader=uploader, alias=file_info.alias)
+            failed.append(file_info)
         else:
             # This is the success case
             CLIMessageDisplay.success(f"Successfully uploaded {file_info.alias}.")
+
+    return BatchPassResult(failed=failed, halted=False)
+
+
+async def _already_uploaded_aliases(upload_client: UploadClient) -> set[str]:
+    """Return the set of aliases already present (non-cancelled) in the upload box.
+
+    These are queried from the Upload API and are used to skip files that have
+    already been uploaded, e.g. by a previous invocation of the batch upload.
+    """
+    uploads = await upload_client.get_box_uploads()
+    return {
+        upload.alias
+        for upload in uploads
+        if (upload.state or "").lower() != _CANCELLED_STATE
+    }
+
+
+def _report_dry_run(pending: list[FileInfoForUpload]) -> None:
+    """Print the files that would be uploaded, without uploading anything.
+
+    The alias, path and size columns are padded to the widest value in each column
+    so they line up vertically for readability.
+    """
+    total_size = sum(fi.decrypted_size for fi in pending)
+    CLIMessageDisplay.display(
+        f"Dry run: {len(pending)} file(s) would be uploaded"
+        + f" ({utils.human_readable_size(total_size)}). No data will be sent."
+    )
+
+    rows = [
+        (fi.alias, str(fi.path), utils.human_readable_size(fi.decrypted_size))
+        for fi in pending
+    ]
+    # Column widths account for both the values and the header labels.
+    alias_width = max(len("ALIAS"), *(len(alias) for alias, _, _ in rows))
+    path_width = max(len("PATH"), *(len(path) for _, path, _ in rows))
+    size_width = max(len("SIZE"), *(len(size) for _, _, size in rows))
+
+    # Header row. The blank runs match the widths of the bullet ("  - "), arrow
+    # ("  ->  ") and "  (" decorations in the data rows below, so the labels line up
+    # over their columns.
+    CLIMessageDisplay.display(
+        f"    {'ALIAS':<{alias_width}}      {'PATH':<{path_width}}"
+        + f"   {'SIZE':>{size_width}}"
+    )
+    for alias, path, size in rows:
+        CLIMessageDisplay.display(
+            f"  - {alias:<{alias_width}}  ->  {path:<{path_width}}"
+            + f"  ({size:>{size_width}})"
+        )
+
+
+async def run_batch_upload(  # noqa: PLR0913
+    *,
+    upload_client: UploadClient,
+    file_info_list: list[FileInfoForUpload],
+    my_private_key: SecretBytes,
+    max_concurrent_uploads: int,
+    max_retries: int = MAX_RETRIES,
+    dry_run: bool = False,
+) -> None:
+    """Upload a batch of files, skipping those already uploaded and retrying failures.
+
+    Files whose alias is already present in the upload box (in any non-cancelled
+    state) are skipped, so re-running the command resumes where a previous run left
+    off. Files that fail to upload are retried up to ``max_retries`` times.
+
+    If ``dry_run`` is True, the upload box is still queried so that already-uploaded
+    files are reported as skipped, but the files that remain are only listed - no
+    uploads are initiated.
+    """
+    already_uploaded = await _already_uploaded_aliases(upload_client)
+    skipped = [fi.alias for fi in file_info_list if fi.alias in already_uploaded]
+    if skipped:
+        CLIMessageDisplay.display(
+            f"Skipping {len(skipped)} file(s) already present in the upload box: "
+            + ", ".join(skipped)
+        )
+
+    pending = [fi for fi in file_info_list if fi.alias not in already_uploaded]
+    if not pending:
+        CLIMessageDisplay.success("All files are already uploaded. Nothing to do.")
+        return
+
+    if dry_run:
+        _report_dry_run(pending)
+        return
+
+    attempt = 0
+    halted = False
+    while True:
+        result = await upload_files_from_list(
+            upload_client=upload_client,
+            file_info_list=pending,
+            my_private_key=my_private_key,
+            max_concurrent_uploads=max_concurrent_uploads,
+        )
+        pending = result.failed
+
+        if not pending:
+            CLIMessageDisplay.success(
+                "Batch upload complete. All files uploaded successfully."
+            )
+            return
+
+        # A halted pass (box full or user abort) is not retried.
+        if result.halted or attempt >= max_retries:
+            halted = result.halted
+            break
+
+        attempt += 1
+        CLIMessageDisplay.display(
+            f"Retrying {len(pending)} failed file(s) (retry {attempt}/{max_retries})..."
+        )
+
+    aliases = ", ".join(fi.alias for fi in pending)
+    if halted:
+        # The stop reason was already reported by upload_files_from_list.
+        CLIMessageDisplay.failure(
+            f"{len(pending)} file(s) were not uploaded: {aliases}"
+        )
+    else:
+        retry_word = "retry" if max_retries == 1 else "retries"
+        CLIMessageDisplay.failure(
+            f"{len(pending)} file(s) did not upload after {max_retries} {retry_word}:"
+            + f" {aliases}"
+        )

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -41,31 +41,32 @@ _CANCELLED_STATE = "cancelled"
 #  eliding the rest, so a large resume doesn't print a wall of text.
 _MAX_LISTED_ALIASES = 10
 
-# Names (aliases/paths) longer than this are middle-elided (keeping the start and end)
-#  when name shortening is enabled, so very long paths don't blow out the output.
+# Aliases longer than this are middle-elided (keeping the start and end) when name
+#  shortening is enabled, so very long aliases don't blow out the output.
 _MAX_NAME_WIDTH = 60
 
 # The marker inserted in place of an elided middle, with surrounding spaces so the
 #  break is visually clear.
 _ELLIPSIS = " … "
 
+# Only elide when doing so shortens the displayed text by at least this many characters.
+#  An elided alias is always _MAX_NAME_WIDTH chars long, so this avoids situations where
+#  we'd only save a few chars
+_MIN_ELISION_SAVINGS = 10
+
 
 def _elide_middle(text: str, max_len: int = _MAX_NAME_WIDTH) -> str:
     """Shorten ``text`` to ``max_len`` chars by replacing its middle with an ellipsis.
 
-    The beginning and end are preserved, which keeps the most useful parts of a path
-    (its root and filename) visible. Text already within ``max_len`` is returned
-    unchanged.
+    The beginning and end are preserved, which keeps the most useful parts of an alias
+    visible. Text is only elided when this saves at least ``_MIN_ELISION_SAVINGS``
+    characters of width; shorter text is returned unchanged.
     """
-    if len(text) <= max_len:
+    if len(text) < max_len + _MIN_ELISION_SAVINGS:
         return text
     keep = max_len - len(_ELLIPSIS)  # reserve room for the ellipsis marker
-    if keep <= 0:
-        return text[:max_len]
     head = (keep + 1) // 2
     tail = keep - head
-    if tail <= 0:
-        return f"{text[:head]}{_ELLIPSIS}"
     return f"{text[:head]}{_ELLIPSIS}{text[-tail:]}"
 
 
@@ -336,7 +337,7 @@ def _report_dry_run(pending: list[FileInfoForUpload], *, shorten: bool) -> None:
 
     The alias, path and size columns are padded to the widest value in each column
     so they line up vertically for readability. If ``shorten`` is set, long aliases
-    and paths are middle-elided.
+    are middle-elided.
     """
     total_size = sum(fi.decrypted_size for fi in pending)
     CLIMessageDisplay.display(
@@ -347,7 +348,7 @@ def _report_dry_run(pending: list[FileInfoForUpload], *, shorten: bool) -> None:
     rows = [
         (
             _display_name(fi.alias, shorten=shorten),
-            _display_name(str(fi.path), shorten=shorten),
+            str(fi.path),
             utils.human_readable_size(fi.decrypted_size),
         )
         for fi in pending
@@ -392,7 +393,7 @@ async def run_batch_upload(  # noqa: PLR0913
     files are reported as skipped, but the files that remain are only listed - no
     uploads are initiated.
 
-    If ``shorten`` is set, long aliases and paths are middle-elided in the output.
+    If ``shorten`` is set, long aliases are middle-elided in the output.
     """
     already_uploaded = await _already_uploaded_aliases(upload_client)
     skipped = [fi.alias for fi in file_info_list if fi.alias in already_uploaded]

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -90,10 +90,8 @@ def parse_file_info_for_upload(file_info: list[str]) -> list[CoreFileInfo]:
 def load_file_info_from_tsv(tsv_path: Path) -> list[CoreFileInfo]:
     """Load file alias/path pairs from a TSV file.
 
-    The TSV is expected to contain the file path in the first column and the file
-    alias in the second column, matching the format used by the GHGA Data Steward
-    Kit. Blank lines are ignored, and a final ``decrypted_size`` is derived for each
-    file from disk.
+    The first column must contain the file path and the second column must contain the
+    file alias. Blank lines are ignored.
 
     Raises:
         FileDoesNotExistError: If the TSV itself, or one of the referenced files,

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -55,16 +55,16 @@ _ELLIPSIS = " … "
 _MIN_ELISION_SAVINGS = 10
 
 
-def _elide_middle(text: str, max_len: int = _MAX_NAME_WIDTH) -> str:
+def _elide_middle(text: str) -> str:
     """Shorten ``text`` to ``max_len`` chars by replacing its middle with an ellipsis.
 
     The beginning and end are preserved, which keeps the most useful parts of an alias
     visible. Text is only elided when this saves at least ``_MIN_ELISION_SAVINGS``
     characters of width; shorter text is returned unchanged.
     """
-    if len(text) < max_len + _MIN_ELISION_SAVINGS:
+    if len(text) < _MAX_NAME_WIDTH + _MIN_ELISION_SAVINGS:
         return text
-    keep = max_len - len(_ELLIPSIS)  # reserve room for the ellipsis marker
+    keep = _MAX_NAME_WIDTH - len(_ELLIPSIS)  # reserve room for the ellipsis marker
     head = (keep + 1) // 2
     tail = keep - head
     return f"{text[:head]}{_ELLIPSIS}{text[-tail:]}"

--- a/src/ghga_connector/core/uploading/ubox_shell.py
+++ b/src/ghga_connector/core/uploading/ubox_shell.py
@@ -309,6 +309,7 @@ class UboxShell:
             FileInfoForUpload(core_file_info=cfi, configured_part_size=config.part_size)
             for cfi in core_file_info
         ]
+        CLIMessageDisplay.display(f"Uploading {len(file_info_list)} file(s)...")
         await upload_files_from_list(
             upload_client=self._upload_client,
             file_info_list=file_info_list,

--- a/src/ghga_connector/core/uploading/ubox_shell.py
+++ b/src/ghga_connector/core/uploading/ubox_shell.py
@@ -39,6 +39,7 @@ from ghga_connector.core.uploading.batch_processing import (
     upload_files_from_list,
 )
 from ghga_connector.core.uploading.structs import FileInfoForUpload, UploadedFileInfo
+from ghga_connector.core.utils import human_readable_size
 from ghga_connector.exceptions import FileNotInBoxError
 
 log = logging.getLogger(__name__)
@@ -189,18 +190,6 @@ def _state_color(state: str | None) -> str | None:
     if state is None:
         return None
     return _STATE_COLOR.get(state.lower())
-
-
-def _human_readable_size(num_bytes: int | None) -> str:
-    """Render a byte count in a compact, human-readable form."""
-    if num_bytes is None:
-        return "-"
-    size = float(num_bytes)
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB", "PiB"):
-        if abs(size) < 1024 or unit == "PiB":
-            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} PiB"
 
 
 class UboxShell:
@@ -435,7 +424,7 @@ def _format_listing(uploads: list[UploadedFileInfo]) -> str:
     rows = [
         (
             upload.alias,
-            _human_readable_size(upload.decrypted_size),
+            human_readable_size(upload.decrypted_size),
             _display_state(upload.state),
             str(upload.file_id),
         )

--- a/src/ghga_connector/core/uploading/uploader.py
+++ b/src/ghga_connector/core/uploading/uploader.py
@@ -49,10 +49,16 @@ class Uploader:
         upload_client: UploadClient,
         file_info: FileInfoForUpload,
         max_concurrent_uploads: int,
+        display_name: str | None = None,
     ):
-        """Instantiate the Uploader"""
+        """Instantiate the Uploader.
+
+        ``display_name`` is used only for the progress bar label; if omitted, the file
+        alias is used. The alias sent to the Upload API is always the full alias.
+        """
         self._upload_client = upload_client
         self._file_alias = file_info.alias
+        self._display_name = display_name or file_info.alias
         self._file_path = file_info.path
         self._file_info = file_info
         self._semaphore = asyncio.Semaphore(max_concurrent_uploads)
@@ -60,7 +66,7 @@ class Uploader:
     def new_progress_bar(self) -> UploadProgressBar:
         """Create a new progress bar"""
         return UploadProgressBar(
-            file_name=self._file_alias, file_size=self._file_info.decrypted_size
+            file_name=self._display_name, file_size=self._file_info.decrypted_size
         )
 
     async def initiate_file_upload(

--- a/src/ghga_connector/core/utils.py
+++ b/src/ghga_connector/core/utils.py
@@ -150,3 +150,15 @@ def detect_duplicates(values: list[Any], field_name: str = ""):
     """Raise an error if there are duplicate values in the list"""
     if len(set(values)) < len(values):
         raise ValueError(f"Duplicate {field_name} values detected.")
+
+
+def human_readable_size(num_bytes: int | None) -> str:
+    """Render a byte count in a compact, human-readable form."""
+    if num_bytes is None:
+        return "-"
+    size = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB", "PiB"):
+        if abs(size) < 1024 or unit == "PiB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} PiB"

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -268,6 +268,24 @@ async def init_upload_placeholder(object_id: str):
     raise NotImplementedError()
 
 
+async def list_box_uploads_placeholder(box_id: str) -> list[dict[str, Any]]:
+    """Placeholder for the box-listing contents. Tests may override this to inject
+    already-uploaded files. By default the box is reported as empty.
+    """
+    return []
+
+
+@mock_external_app.get(UPLOAD + "/boxes/{box_id}/uploads")
+async def list_box_uploads(box_id: UUID):
+    """Mock for the Upload API's GET /boxes/{box_id}/uploads endpoint.
+
+    Returns the list of FileUploads contained in the box. Used by the batch upload
+    to skip files that have already been uploaded.
+    """
+    contents = await list_box_uploads_placeholder(str(box_id))
+    return JSONResponse(status_code=200, content=contents)
+
+
 @mock_external_app.post(UPLOAD + "/boxes/{box_id}/uploads")
 async def create_file_upload(box_id: UUID, request: Request):
     """Mock for Upload API's POST /boxes/{box_id}/uploads endpoint.

--- a/tests/fixtures/mock_api/app.py
+++ b/tests/fixtures/mock_api/app.py
@@ -268,22 +268,14 @@ async def init_upload_placeholder(object_id: str):
     raise NotImplementedError()
 
 
-async def list_box_uploads_placeholder(box_id: str) -> list[dict[str, Any]]:
-    """Placeholder for the box-listing contents. Tests may override this to inject
-    already-uploaded files. By default the box is reported as empty.
-    """
-    return []
-
-
 @mock_external_app.get(UPLOAD + "/boxes/{box_id}/uploads")
 async def list_box_uploads(box_id: UUID):
     """Mock for the Upload API's GET /boxes/{box_id}/uploads endpoint.
 
-    Returns the list of FileUploads contained in the box. Used by the batch upload
-    to skip files that have already been uploaded.
+    For now this always returns an empty list. To make dynamic, add an overridable
+    method like `init_upload_placeholder()`.
     """
-    contents = await list_box_uploads_placeholder(str(box_id))
-    return JSONResponse(status_code=200, content=contents)
+    return JSONResponse(status_code=200, content=[])
 
 
 @mock_external_app.post(UPLOAD + "/boxes/{box_id}/uploads")

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import SecretBytes
 
 from ghga_connector import exceptions
+from ghga_connector.constants import BATCH_RETRY_BACKOFF_SEC
 from ghga_connector.core.uploading.batch_processing import (
     BatchPassResult,
     run_batch_upload,
@@ -454,6 +455,35 @@ async def test_run_batch_upload_dry_run_aligns_columns(tmp_path):
     assert header.index("SIZE") + len("SIZE") == lines[0].index(")")
 
 
+async def test_run_batch_upload_elides_long_skip_list():
+    """A long list of already-uploaded files is elided in the skip message."""
+    file_infos = [
+        make_file_info_for_upload(path=Path(f"/tmp/file-{i}.bam"), alias=f"file-{i}")
+        for i in range(12)
+    ]
+    box = [
+        UploadedFileInfo(id=uuid4(), alias=f"file-{i}", state="interrogated")
+        for i in range(12)
+    ]
+    with patch(
+        "ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"
+    ) as mock_display:
+        await run_batch_upload(
+            upload_client=_make_upload_client(box),
+            file_info_list=file_infos,
+            my_private_key=SecretBytes(b"\x00" * 32),
+            max_concurrent_uploads=1,
+        )
+
+    messages = " ".join(
+        str(call.args[0]) for call in mock_display.display.call_args_list
+    )
+    assert "Skipping 12 file(s)" in messages
+    # Only the first 10 aliases are listed; the remainder are summarized.
+    assert "(+2 more)" in messages
+    assert "file-11" not in messages
+
+
 async def test_run_batch_upload_retries_failures():
     """Failed files are retried, and a retry that succeeds ends the loop."""
     with NamedTemporaryFile() as f:
@@ -469,9 +499,15 @@ async def test_run_batch_upload_retries_failures():
                 return BatchPassResult(failed=[failing], halted=False)
             return BatchPassResult(failed=[], halted=False)
 
-        with patch(
-            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
-            fake_batch_cycle,
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+                fake_batch_cycle,
+            ),
+            patch(
+                "ghga_connector.core.uploading.batch_processing.asyncio.sleep",
+                AsyncMock(),
+            ),
         ):
             await run_batch_upload(
                 upload_client=upload_client,
@@ -497,9 +533,15 @@ async def test_run_batch_upload_stops_after_max_retries():
             call_count += 1
             return BatchPassResult(failed=[failing], halted=False)
 
-        with patch(
-            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
-            fake_batch_cycle,
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+                fake_batch_cycle,
+            ),
+            patch(
+                "ghga_connector.core.uploading.batch_processing.asyncio.sleep",
+                AsyncMock(),
+            ) as mock_sleep,
         ):
             await run_batch_upload(
                 upload_client=upload_client,
@@ -511,6 +553,9 @@ async def test_run_batch_upload_stops_after_max_retries():
 
         # 1 initial pass + 2 retries
         assert call_count == 3
+        # One backoff wait precedes each of the 2 retries.
+        assert mock_sleep.await_count == 2
+        assert mock_sleep.await_args_list[0].args == (BATCH_RETRY_BACKOFF_SEC,)
 
 
 async def test_run_batch_upload_does_not_retry_when_halted():

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -24,7 +24,12 @@ import pytest
 from pydantic import SecretBytes
 
 from ghga_connector import exceptions
-from ghga_connector.core.uploading.batch_processing import upload_files_from_list
+from ghga_connector.core.uploading.batch_processing import (
+    BatchPassResult,
+    run_batch_upload,
+    upload_files_from_list,
+)
+from ghga_connector.core.uploading.structs import UploadedFileInfo
 from tests.fixtures.utils import (
     TEST_FILE_ID,
     TEST_STORAGE_ALIAS1,
@@ -192,3 +197,345 @@ async def test_upload_files_from_list_processes_each_file():
         for mock_uploader in [mock_uploader_1, mock_uploader_2]:
             mock_uploader.initiate_file_upload.assert_called_once()
             mock_uploader.upload_file.assert_called_once()
+
+
+async def test_upload_files_from_list_reports_failures():
+    """Make sure that if a file upload results in an error, the file is returned in the
+    result's failed list.
+    """
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="ok"),
+            make_file_info_for_upload(path=Path(f2.name), alias="bad"),
+        ]
+        good_uploader = make_mock_uploader()
+        bad_uploader = make_mock_uploader(upload_raises=RuntimeError("problem"))
+
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.Uploader",
+                side_effect=[good_uploader, bad_uploader],
+            ),
+            patch("ghga_connector.core.uploading.batch_processing.Crypt4GHEncryptor"),
+        ):
+            result = await upload_files_from_list(
+                upload_client=AsyncMock(),
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+            )
+
+        assert not result.halted
+        assert [fi.alias for fi in result.failed] == ["bad"]
+
+
+async def test_upload_files_from_list_halts_on_box_full():
+    """Test that when the box is full, processing stops and reports remaining files as failed."""
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="first"),
+            make_file_info_for_upload(path=Path(f2.name), alias="second"),
+        ]
+
+        def _box_full():
+            try:
+                raise exceptions.UploadBoxSizeExceededError(
+                    file_alias="first", file_upload_box_id=uuid4()
+                )
+            except Exception as exc:
+                raise exceptions.CreateFileUploadError(
+                    file_alias="first", exception=exc
+                ) from exc
+
+        failing_uploader = AsyncMock()
+        failing_uploader.initiate_file_upload.side_effect = _box_full
+        second_uploader = make_mock_uploader()
+
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.Uploader",
+                side_effect=[failing_uploader, second_uploader],
+            ),
+            patch("ghga_connector.core.uploading.batch_processing.Crypt4GHEncryptor"),
+        ):
+            result = await upload_files_from_list(
+                upload_client=AsyncMock(),
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+            )
+
+        assert result.halted
+        # Both the file that triggered the error and the un-attempted file are reported.
+        assert [fi.alias for fi in result.failed] == ["first", "second"]
+        second_uploader.initiate_file_upload.assert_not_called()
+
+
+def _make_upload_client(box_contents: list[UploadedFileInfo]) -> AsyncMock:
+    """Create a mock UploadClient whose get_box_uploads returns box_contents."""
+    upload_client = AsyncMock()
+    upload_client.get_box_uploads.return_value = box_contents
+    return upload_client
+
+
+async def test_run_batch_upload_skips_already_uploaded():
+    """Files already present (non-cancelled) in the box are not re-uploaded."""
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="already"),
+            make_file_info_for_upload(path=Path(f2.name), alias="fresh"),
+        ]
+        upload_client = _make_upload_client(
+            [UploadedFileInfo(id=uuid4(), alias="already", state="interrogated")]
+        )
+
+        captured: list[list[str]] = []
+
+        async def fake_batch_cycle(*, file_info_list, **_kwargs):
+            captured.append([fi.alias for fi in file_info_list])
+            return BatchPassResult(failed=[], halted=False)
+
+        with patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            fake_batch_cycle,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=0,
+            )
+
+        # Only the fresh file should have been passed to the uploader.
+        assert captured == [["fresh"]]
+
+
+async def test_run_batch_upload_does_not_skip_cancelled():
+    """A cancelled (deleted) alias in the box is re-uploaded, not skipped."""
+    with NamedTemporaryFile() as f:
+        file_infos = [make_file_info_for_upload(path=Path(f.name), alias="redo")]
+        upload_client = _make_upload_client(
+            [UploadedFileInfo(id=uuid4(), alias="redo", state="cancelled")]
+        )
+
+        captured: list[list[str]] = []
+
+        async def fake_batch_cycle(*, file_info_list, **_kwargs):
+            captured.append([fi.alias for fi in file_info_list])
+            return BatchPassResult(failed=[], halted=False)
+
+        with patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            fake_batch_cycle,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=0,
+            )
+
+        assert captured == [["redo"]]
+
+
+async def test_run_batch_upload_all_skipped_does_not_upload():
+    """When every file is already uploaded, no upload pass is attempted."""
+    with NamedTemporaryFile() as f:
+        file_infos = [make_file_info_for_upload(path=Path(f.name), alias="done")]
+        upload_client = _make_upload_client(
+            [UploadedFileInfo(id=uuid4(), alias="done", state="interrogated")]
+        )
+
+        fake_batch_cycle = AsyncMock()
+        with patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            fake_batch_cycle,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=3,
+            )
+
+        fake_batch_cycle.assert_not_called()
+
+
+async def test_run_batch_upload_dry_run_does_not_upload():
+    """In dry-run mode, already-uploaded files are still skipped but nothing uploads."""
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="already"),
+            make_file_info_for_upload(path=Path(f2.name), alias="fresh"),
+        ]
+        upload_client = _make_upload_client(
+            [UploadedFileInfo(id=uuid4(), alias="already", state="interrogated")]
+        )
+
+        fake_batch_cycle = AsyncMock()
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+                fake_batch_cycle,
+            ),
+            patch(
+                "ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"
+            ) as mock_display,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=3,
+                dry_run=True,
+            )
+
+        # No upload pass is attempted in dry-run mode.
+        fake_batch_cycle.assert_not_called()
+
+        # The box is still queried so already-uploaded files are reported as skipped.
+        upload_client.get_box_uploads.assert_awaited_once()
+        messages = " ".join(
+            str(call.args[0]) for call in mock_display.display.call_args_list
+        )
+        assert "Dry run" in messages
+        # The fresh file is listed as one that would be uploaded; the skipped one is not.
+        assert "fresh" in messages
+        assert "Skipping 1 file(s)" in messages
+
+
+async def test_run_batch_upload_dry_run_aligns_columns(tmp_path):
+    """Dry-run file rows align their arrow, path and size columns vertically."""
+    short = tmp_path / "a.bam"
+    short.write_bytes(b"x")
+    longer = tmp_path / "much-longer-name.bam"
+    longer.write_bytes(b"x" * 2048)
+    file_infos = [
+        make_file_info_for_upload(path=short, alias="a", decrypted_size=1),
+        make_file_info_for_upload(
+            path=longer, alias="longer-alias", decrypted_size=2048
+        ),
+    ]
+
+    with (
+        patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            AsyncMock(),
+        ),
+        patch(
+            "ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"
+        ) as mock_display,
+    ):
+        await run_batch_upload(
+            upload_client=_make_upload_client([]),
+            file_info_list=file_infos,
+            my_private_key=SecretBytes(b"\x00" * 32),
+            max_concurrent_uploads=1,
+            dry_run=True,
+        )
+
+    all_lines = [str(call.args[0]) for call in mock_display.display.call_args_list]
+    lines = [line for line in all_lines if line.startswith("  - ")]
+    assert len(lines) == 2
+    # The arrow and both parentheses occupy the same column in every row.
+    assert len({line.index("->") for line in lines}) == 1
+    assert len({line.index("(") for line in lines}) == 1
+    assert len({line.index(")") for line in lines}) == 1
+
+    # A header row labels the columns and lines up over them.
+    header = next(line for line in all_lines if "ALIAS" in line)
+    assert "PATH" in header and "SIZE" in header
+    assert header.index("ALIAS") == len("  - ")
+    assert header.index("PATH") == lines[0].index("->") + len("->  ")
+    assert header.index("SIZE") + len("SIZE") == lines[0].index(")")
+
+
+async def test_run_batch_upload_retries_failures():
+    """Failed files are retried, and a retry that succeeds ends the loop."""
+    with NamedTemporaryFile() as f:
+        failing = make_file_info_for_upload(path=Path(f.name), alias="flaky")
+        upload_client = _make_upload_client([])
+
+        calls: list[list[str]] = []
+
+        async def fake_batch_cycle(*, file_info_list, **_kwargs):
+            calls.append([fi.alias for fi in file_info_list])
+            # Fail on the first pass, succeed on the retry.
+            if len(calls) == 1:
+                return BatchPassResult(failed=[failing], halted=False)
+            return BatchPassResult(failed=[], halted=False)
+
+        with patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            fake_batch_cycle,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=[failing],
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=3,
+            )
+
+        assert calls == [["flaky"], ["flaky"]]
+
+
+async def test_run_batch_upload_stops_after_max_retries():
+    """Persistent failures stop after the initial pass plus max_retries retries."""
+    with NamedTemporaryFile() as f:
+        failing = make_file_info_for_upload(path=Path(f.name), alias="doomed")
+        upload_client = _make_upload_client([])
+
+        call_count = 0
+
+        async def fake_batch_cycle(*, file_info_list, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            return BatchPassResult(failed=[failing], halted=False)
+
+        with patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            fake_batch_cycle,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=[failing],
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=2,
+            )
+
+        # 1 initial pass + 2 retries
+        assert call_count == 3
+
+
+async def test_run_batch_upload_does_not_retry_when_halted():
+    """A halted pass (e.g. box full) is not retried even if retries remain."""
+    with NamedTemporaryFile() as f:
+        failing = make_file_info_for_upload(path=Path(f.name), alias="halt-me")
+        upload_client = _make_upload_client([])
+
+        call_count = 0
+
+        async def fake_batch_cycle(*, file_info_list, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            return BatchPassResult(failed=[failing], halted=True)
+
+        with patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            fake_batch_cycle,
+        ):
+            await run_batch_upload(
+                upload_client=upload_client,
+                file_info_list=[failing],
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                max_retries=5,
+            )
+
+        assert call_count == 1

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -26,7 +26,10 @@ from pydantic import SecretBytes
 from ghga_connector import exceptions
 from ghga_connector.constants import BATCH_RETRY_BACKOFF_SEC
 from ghga_connector.core.uploading.batch_processing import (
+    _MAX_NAME_WIDTH,
+    _MIN_ELISION_SAVINGS,
     BatchPassResult,
+    _elide_middle,
     run_batch_upload,
     upload_files_from_list,
 )
@@ -519,8 +522,35 @@ async def _dry_run_lines(file_infos, *, shorten):
     ]
 
 
-async def test_run_batch_upload_dry_run_elides_long_fields_when_shortened():
-    """With shorten=True, very long aliases and paths are middle-elided."""
+async def test_elide_middle_keeps_text_below_savings_threshold():
+    """An alias only marginally over the width limit is returned unchanged, since
+    eliding it would hide content for little width benefit.
+    """
+    # One char short of the point where eliding would save _MIN_ELISION_SAVINGS chars.
+    text = "a" * (_MAX_NAME_WIDTH + _MIN_ELISION_SAVINGS - 1)
+    assert _elide_middle(text) == text
+
+
+async def test_elide_middle_elides_once_savings_threshold_met():
+    """Once eliding saves at least _MIN_ELISION_SAVINGS chars, the alias is middle-elided
+    down to the width limit.
+    """
+    text = "head" + "x" * (_MAX_NAME_WIDTH + _MIN_ELISION_SAVINGS) + "tail"
+    assert len(text) >= _MAX_NAME_WIDTH + _MIN_ELISION_SAVINGS
+
+    result = _elide_middle(text)
+
+    assert result != text
+    assert len(result) == _MAX_NAME_WIDTH
+    assert " … " in result
+    assert result.startswith("head")
+    assert result.endswith("tail")
+
+
+async def test_run_batch_upload_dry_run_elides_long_alias_when_shortened():
+    """With shorten=True, very long aliases are middle-elided but paths are shown
+    in full.
+    """
     long_alias = "alias-" + "x" * 90
     long_path = Path("/data/" + "deep/" * 30 + "final-file.bam")
     file_infos = [
@@ -529,12 +559,11 @@ async def test_run_batch_upload_dry_run_elides_long_fields_when_shortened():
 
     (line,) = await _dry_run_lines(file_infos, shorten=True)
 
-    # The full values are not shown verbatim, but their start and end survive.
+    # The alias is elided, keeping its start and end, while the path is left intact.
     assert " … " in line  # ellipsis is surrounded by spaces
     assert long_alias not in line
-    assert str(long_path) not in line
     assert long_alias[:10] in line  # head of the alias kept
-    assert "final-file.bam" in line  # tail of the path kept
+    assert str(long_path) in line  # path is never elided
 
 
 async def test_run_batch_upload_dry_run_shows_full_names_by_default():

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -272,6 +272,44 @@ async def test_upload_files_from_list_halts_on_box_full():
         second_uploader.initiate_file_upload.assert_not_called()
 
 
+async def test_upload_files_from_list_shortens_alias_in_messages():
+    """With shorten=True, long aliases are middle-elided in live upload messages."""
+    long_alias = "sample-" + "z" * 90
+    with NamedTemporaryFile() as f:
+        file_info = make_file_info_for_upload(path=Path(f.name), alias=long_alias)
+        mock_uploader = make_mock_uploader()
+
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.Uploader",
+                return_value=mock_uploader,
+            ) as mock_uploader_cls,
+            patch("ghga_connector.core.uploading.batch_processing.Crypt4GHEncryptor"),
+            patch(
+                "ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"
+            ) as mock_display,
+        ):
+            await upload_files_from_list(
+                upload_client=AsyncMock(),
+                file_info_list=[file_info],
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+                shorten=True,
+            )
+
+        messages = " ".join(
+            str(call.args[0]) for call in mock_display.success.call_args_list
+        )
+        assert " … " in messages  # the alias was elided
+        assert long_alias not in messages
+
+        # The progress bar (Uploader.display_name) also gets the elided name, while the
+        # full alias is preserved for the API calls.
+        display_name = mock_uploader_cls.call_args.kwargs["display_name"]
+        assert " … " in display_name
+        assert long_alias not in display_name
+
+
 def _make_upload_client(box_contents: list[UploadedFileInfo]) -> AsyncMock:
     """Create a mock UploadClient whose get_box_uploads returns box_contents."""
     upload_client = AsyncMock()
@@ -453,6 +491,65 @@ async def test_run_batch_upload_dry_run_aligns_columns(tmp_path):
     assert header.index("ALIAS") == len("  - ")
     assert header.index("PATH") == lines[0].index("->") + len("->  ")
     assert header.index("SIZE") + len("SIZE") == lines[0].index(")")
+
+
+async def _dry_run_lines(file_infos, *, shorten):
+    """Run a dry-run and return the per-file table rows that were displayed."""
+    with (
+        patch(
+            "ghga_connector.core.uploading.batch_processing.upload_files_from_list",
+            AsyncMock(),
+        ),
+        patch(
+            "ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"
+        ) as mock_display,
+    ):
+        await run_batch_upload(
+            upload_client=_make_upload_client([]),
+            file_info_list=file_infos,
+            my_private_key=SecretBytes(b"\x00" * 32),
+            max_concurrent_uploads=1,
+            dry_run=True,
+            shorten=shorten,
+        )
+    return [
+        str(call.args[0])
+        for call in mock_display.display.call_args_list
+        if str(call.args[0]).startswith("  - ")
+    ]
+
+
+async def test_run_batch_upload_dry_run_elides_long_fields_when_shortened():
+    """With shorten=True, very long aliases and paths are middle-elided."""
+    long_alias = "alias-" + "x" * 90
+    long_path = Path("/data/" + "deep/" * 30 + "final-file.bam")
+    file_infos = [
+        make_file_info_for_upload(path=long_path, alias=long_alias, decrypted_size=10)
+    ]
+
+    (line,) = await _dry_run_lines(file_infos, shorten=True)
+
+    # The full values are not shown verbatim, but their start and end survive.
+    assert " … " in line  # ellipsis is surrounded by spaces
+    assert long_alias not in line
+    assert str(long_path) not in line
+    assert long_alias[:10] in line  # head of the alias kept
+    assert "final-file.bam" in line  # tail of the path kept
+
+
+async def test_run_batch_upload_dry_run_shows_full_names_by_default():
+    """With shorten=False (default), long aliases and paths are shown in full."""
+    long_alias = "alias-" + "x" * 90
+    long_path = Path("/data/" + "deep/" * 30 + "final-file.bam")
+    file_infos = [
+        make_file_info_for_upload(path=long_path, alias=long_alias, decrypted_size=10)
+    ]
+
+    (line,) = await _dry_run_lines(file_infos, shorten=False)
+
+    assert "…" not in line
+    assert long_alias in line
+    assert str(long_path) in line
 
 
 async def test_run_batch_upload_elides_long_skip_list():

--- a/tests/unit/test_tsv_loading.py
+++ b/tests/unit/test_tsv_loading.py
@@ -1,0 +1,143 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for load_file_info_from_tsv in batch_processing"""
+
+from pathlib import Path
+
+import pytest
+
+from ghga_connector import exceptions
+from ghga_connector.core.uploading.batch_processing import load_file_info_from_tsv
+
+
+def _write_tsv(tmp_path: Path, lines: list[str]) -> Path:
+    tsv_path = tmp_path / "files.tsv"
+    tsv_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return tsv_path
+
+
+def test_parses_path_then_alias(tmp_path):
+    """The first column is the path and the second is the alias (ds-kit format)."""
+    data_file = tmp_path / "sample.bam"
+    data_file.write_bytes(b"hello")
+    tsv_path = _write_tsv(tmp_path, [f"{data_file}\tmy-alias"])
+
+    result = load_file_info_from_tsv(tsv_path)
+
+    assert len(result) == 1
+    assert result[0].alias == "my-alias"
+    assert result[0].path == data_file.resolve()
+    assert result[0].decrypted_size == 5
+
+
+def test_ignores_blank_lines(tmp_path):
+    """Blank lines in the TSV are skipped."""
+    first = tmp_path / "a.bam"
+    first.write_bytes(b"a")
+    second = tmp_path / "b.bam"
+    second.write_bytes(b"bb")
+    tsv_path = _write_tsv(tmp_path, [f"{first}\talias-a", "", f"{second}\talias-b", ""])
+
+    result = load_file_info_from_tsv(tsv_path)
+
+    assert {fi.alias for fi in result} == {"alias-a", "alias-b"}
+
+
+def test_extra_columns_are_ignored(tmp_path):
+    """Only the first two columns (path, alias) are used; extra columns are ignored."""
+    data_file = tmp_path / "a.bam"
+    data_file.write_bytes(b"a")
+    tsv_path = _write_tsv(tmp_path, [f"{data_file}\tthe-alias\tsomething-else"])
+
+    result = load_file_info_from_tsv(tsv_path)
+
+    assert len(result) == 1
+    assert result[0].alias == "the-alias"
+
+
+def test_no_tab_raises(tmp_path):
+    """A line with no tab character raises a RuntimeError."""
+    data_file = tmp_path / "a.bam"
+    data_file.write_bytes(b"a")
+    tsv_path = _write_tsv(tmp_path, [str(data_file)])
+
+    with pytest.raises(RuntimeError, match="must be tab-separated"):
+        load_file_info_from_tsv(tsv_path)
+
+
+def test_space_separated_line_hints_at_spaces(tmp_path):
+    """A space-separated line gets a targeted hint about using spaces, not tabs."""
+    data_file = tmp_path / "a.bam"
+    data_file.write_bytes(b"a")
+    tsv_path = _write_tsv(tmp_path, [f"{data_file}    the-alias"])
+
+    with pytest.raises(RuntimeError, match="separates the columns with spaces"):
+        load_file_info_from_tsv(tsv_path)
+
+
+def test_empty_alias_column_raises(tmp_path):
+    """A line whose alias column is empty (between tabs) raises a RuntimeError."""
+    data_file = tmp_path / "a.bam"
+    data_file.write_bytes(b"a")
+    tsv_path = _write_tsv(tmp_path, [f"{data_file}\t\textra"])
+
+    with pytest.raises(RuntimeError, match="missing a file path or alias"):
+        load_file_info_from_tsv(tsv_path)
+
+
+def test_missing_tsv_raises(tmp_path):
+    """A non-existent TSV path raises FileDoesNotExistError."""
+    with pytest.raises(exceptions.FileDoesNotExistError):
+        load_file_info_from_tsv(tmp_path / "nope.tsv")
+
+
+def test_missing_referenced_file_raises(tmp_path):
+    """A TSV referencing a file that does not exist raises FileDoesNotExistError."""
+    tsv_path = _write_tsv(tmp_path, [f"{tmp_path / 'ghost.bam'}\tghost"])
+
+    with pytest.raises(exceptions.FileDoesNotExistError):
+        load_file_info_from_tsv(tsv_path)
+
+
+def test_duplicate_alias_raises(tmp_path):
+    """Duplicate aliases across rows raise a ValueError."""
+    first = tmp_path / "a.bam"
+    first.write_bytes(b"a")
+    second = tmp_path / "b.bam"
+    second.write_bytes(b"bb")
+    tsv_path = _write_tsv(tmp_path, [f"{first}\tsame", f"{second}\tsame"])
+
+    with pytest.raises(ValueError, match="Duplicate alias"):
+        load_file_info_from_tsv(tsv_path)
+
+
+def test_duplicate_path_raises(tmp_path):
+    """The same file path under two aliases raises a ValueError."""
+    data_file = tmp_path / "a.bam"
+    data_file.write_bytes(b"a")
+    tsv_path = _write_tsv(tmp_path, [f"{data_file}\tone", f"{data_file}\ttwo"])
+
+    with pytest.raises(ValueError, match="Duplicate path"):
+        load_file_info_from_tsv(tsv_path)
+
+
+def test_empty_file_raises(tmp_path):
+    """An empty TSV raises a RuntimeError."""
+    tsv_path = tmp_path / "empty.tsv"
+    tsv_path.write_text("\n\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="No file entries"):
+        load_file_info_from_tsv(tsv_path)

--- a/tests/unit/test_ubox_shell.py
+++ b/tests/unit/test_ubox_shell.py
@@ -33,8 +33,8 @@ from ghga_connector.core.uploading.ubox_shell import (
     _expand_globs,
     _extract_alias,
     _format_listing,
-    _human_readable_size,
 )
+from ghga_connector.core.utils import human_readable_size
 from ghga_connector.exceptions import FileNotInBoxError
 
 
@@ -101,10 +101,10 @@ def test_expand_globs(tmp_path: Path):
 
 def test_human_readable_size():
     """Byte counts are rendered compactly."""
-    assert _human_readable_size(None) == "-"
-    assert _human_readable_size(512) == "512 B"
-    assert _human_readable_size(1024) == "1.0 KiB"
-    assert _human_readable_size(1024**2) == "1.0 MiB"
+    assert human_readable_size(None) == "-"
+    assert human_readable_size(512) == "512 B"
+    assert human_readable_size(1024) == "1.0 KiB"
+    assert human_readable_size(1024**2) == "1.0 MiB"
 
 
 def test_format_listing_contains_fields():

--- a/tests/unit/test_upload_main.py
+++ b/tests/unit/test_upload_main.py
@@ -123,6 +123,7 @@ async def test_upload_files_applies_config_part_size(
         max_concurrent_uploads,
         max_retries,
         dry_run,
+        shorten,
     ):
         captured.extend(file_info_list)
 

--- a/tests/unit/test_upload_main.py
+++ b/tests/unit/test_upload_main.py
@@ -23,7 +23,8 @@ import httpx
 import pytest
 
 from ghga_connector import exceptions
-from ghga_connector.core.main import parse_file_info_for_upload, upload_files
+from ghga_connector.core.main import upload_files
+from ghga_connector.core.uploading.batch_processing import parse_file_info_for_upload
 from ghga_connector.core.uploading.structs import CoreFileInfo, FileInfoForUpload
 from tests.fixtures import set_runtime_test_config  # noqa: F401
 from tests.fixtures.config import get_test_config
@@ -114,16 +115,22 @@ async def test_upload_files_applies_config_part_size(
     test_part_size = 12 * 1024 * 1024  # 12 MiB — a value distinct from the default
     captured: list[FileInfoForUpload] = []
 
-    async def mock_upload_files_from_list(
-        *, upload_client, file_info_list, my_private_key, max_concurrent_uploads
+    async def mock_run_batch_upload(
+        *,
+        upload_client,
+        file_info_list,
+        my_private_key,
+        max_concurrent_uploads,
+        max_retries,
+        dry_run,
     ):
         captured.extend(file_info_list)
 
     with (
         NamedTemporaryFile() as f,
         patch(
-            "ghga_connector.core.main.upload_files_from_list",
-            mock_upload_files_from_list,
+            "ghga_connector.core.main.run_batch_upload",
+            mock_run_batch_upload,
         ),
         patch(
             "ghga_connector.core.uploading.api_calls.is_service_healthy",

--- a/tests/unit/test_uploader.py
+++ b/tests/unit/test_uploader.py
@@ -81,6 +81,30 @@ def make_uploader(
     )
 
 
+async def test_new_progress_bar_uses_display_name():
+    """The progress bar label uses display_name when given, else the file alias."""
+    with NamedTemporaryFile() as f:
+        file_info = make_file_info_for_upload(
+            path=Path(f.name), alias=FILE_ALIAS, decrypted_size=1000
+        )
+
+        # Default: the bar falls back to the file alias.
+        default = Uploader(
+            upload_client=AsyncMock(), file_info=file_info, max_concurrent_uploads=1
+        )
+        assert default.new_progress_bar()._file_name == FILE_ALIAS
+
+        # An explicit display_name is used for the bar; the API alias is untouched.
+        custom = Uploader(
+            upload_client=AsyncMock(),
+            file_info=file_info,
+            max_concurrent_uploads=1,
+            display_name="short … name",
+        )
+        assert custom.new_progress_bar()._file_name == "short … name"
+        assert custom._file_alias == FILE_ALIAS
+
+
 async def test_initiate_file_upload_returns_file_id():
     """Make sure initiate_file_upload returns the file ID provided by the upload client."""
     with NamedTemporaryFile() as f:


### PR DESCRIPTION
This adapts the semi-implemented batch upload so it works like the DS Kit: takes a `--tsv` parameter and has a `--dry-run` feature.

Also added a `--shorten-names` flag to cut out the middle of long aliases and paths for more readable output (doesn't change what actually gets sent to us, it's just for the display).