### PR TITLE
Fix keyboard cancellation

### DIFF
--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -42,7 +42,7 @@ def _catch_cancellations(coroutine) -> None:
     try:
         asyncio.run(coroutine)
     except KeyboardInterrupt:
-        CLIMessageDisplay.failure("The operation was aborted.")
+        CLIMessageDisplay.failure("The operation was aborted by the user.")
         raise typer.Exit(code=_SIGINT_EXIT_CODE) from None
 
 

--- a/src/ghga_connector/cli.py
+++ b/src/ghga_connector/cli.py
@@ -33,6 +33,18 @@ from ghga_connector.core.utils import modify_for_debug
 
 cli = typer.Typer(no_args_is_help=True)
 
+# Standard shell exit code for a process terminated by SIGINT (Ctrl+C).
+_SIGINT_EXIT_CODE = 130
+
+
+def _catch_cancellations(coroutine) -> None:
+    """Run an async command, exiting cleanly if the user aborts with Ctrl+C."""
+    try:
+        asyncio.run(coroutine)
+    except KeyboardInterrupt:
+        CLIMessageDisplay.failure("The operation was aborted.")
+        raise typer.Exit(code=_SIGINT_EXIT_CODE) from None
+
 
 @cli.command(name="batch-upload", no_args_is_help=True)
 def batch_upload(  # noqa: PLR0913
@@ -87,7 +99,7 @@ def batch_upload(  # noqa: PLR0913
     to resume an interrupted batch. Files that fail to upload are retried automatically.
     """
     modify_for_debug(debug)
-    asyncio.run(
+    _catch_cancellations(
         async_batch_upload(
             tsv=tsv,
             my_public_key_path=my_public_key_path,
@@ -123,7 +135,7 @@ def ubox(
 ):
     """Open an interactive shell to manage an upload box (upload, ls, rm)."""
     modify_for_debug(debug)
-    asyncio.run(
+    _catch_cancellations(
         async_ubox(
             my_public_key_path=my_public_key_path,
             my_private_key_path=my_private_key_path,
@@ -165,7 +177,7 @@ def download(  # noqa: PLR0913
 ):
     """Wrapper for the async download function"""
     modify_for_debug(debug)
-    asyncio.run(
+    _catch_cancellations(
         async_download(
             output_dir=output_dir,
             my_public_key_path=my_public_key_path,

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -183,6 +183,9 @@ def load_file_info_from_tsv(tsv_path: Path) -> list[CoreFileInfo]:
     return items
 
 
+_USER_ABORT_EXCEPTIONS = (KeyboardInterrupt, asyncio.CancelledError)
+
+
 def _signal_handler(signum, frame):
     """Capture KeyboardInterrupt"""
     CLIMessageDisplay.display("Cleanup in progress, please wait…")
@@ -191,9 +194,14 @@ def _signal_handler(signum, frame):
 async def perform_cleanup(*, uploader: Uploader, alias: str) -> None:
     """Perform file cleanup after an error or user cancellation.
 
-    Prevents subsequent keyboard cancellations from disrupting cleanup process.
+    Prevents a keyboard cancellation from disrupting the cleanup itself by swallowing
+    SIGINT for the duration of the cleanup, then restoring the previous handler so that
+    subsequent files in the batch can still be aborted with Ctrl+C.
+
+    Note: ``signal.signal()`` only works on the main thread, which is where the CLI runs
+    (via ``asyncio.run``), so this is safe here.
     """
-    signal.signal(signal.SIGINT, _signal_handler)
+    previous_handler = signal.signal(signal.SIGINT, _signal_handler)
 
     try:
         await uploader.delete_file()
@@ -208,6 +216,8 @@ async def perform_cleanup(*, uploader: Uploader, alias: str) -> None:
             "Upload process stopped. If applicable, any previously completed"
             + " file uploads remain uploaded."
         )
+    finally:
+        signal.signal(signal.SIGINT, previous_handler)
 
 
 @dataclass
@@ -259,6 +269,20 @@ async def upload_files_from_list(
 
         try:
             file_id, storage_alias = await uploader.initiate_file_upload()
+        except _USER_ABORT_EXCEPTIONS:
+            # Ctrl+C during initiation (before any bytes flow) halts the batch cleanly,
+            # mirroring the abort handling around upload_file() below. Note: initiation
+            # may already have created a server-side FileUpload before the interrupt;
+            # because no file_id was returned, we can't delete it here, so an orphan may
+            # be left in the "init" state. It can be removed manually with `ubox rm`.
+            CLIMessageDisplay.failure(
+                f"Cancelled upload for {display_alias}. It is possible that the server-"
+                + "side upload was created anyway. If you are unable to create a new"
+                + f" upload for {display_alias} because of this, remove the server-side"
+                + f" upload by running `ghga-connector ubox`, then `rm {display_alias}`."
+            )
+            failed.extend(file_info_list[index:])
+            return BatchPassResult(failed=failed, halted=True)
         except Exception as err:
             CLIMessageDisplay.failure(str(err))
 
@@ -292,10 +316,10 @@ async def upload_files_from_list(
         )
         try:
             await uploader.upload_file(encryptor=encryptor)
-        except KeyboardInterrupt:
-            # User cancellation is handled here
+        except _USER_ABORT_EXCEPTIONS:
+            # User cancellation is handled here.
             CLIMessageDisplay.failure(
-                f"User aborted upload for {display_alias}, (file ID {file_id}), deleting."
+                f"Upload aborted for {display_alias}, (file ID {file_id}), deleting."
             )
             await perform_cleanup(uploader=uploader, alias=display_alias)
             # An explicit user abort stops the whole batch rather than retrying.

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -269,12 +269,13 @@ async def upload_files_from_list(
 
         try:
             file_id, storage_alias = await uploader.initiate_file_upload()
-        except _USER_ABORT_EXCEPTIONS:
+        except KeyboardInterrupt:
             # Ctrl+C during initiation (before any bytes flow) halts the batch cleanly,
             # mirroring the abort handling around upload_file() below. Note: initiation
             # may already have created a server-side FileUpload before the interrupt;
             # because no file_id was returned, we can't delete it here, so an orphan may
             # be left in the "init" state. It can be removed manually with `ubox rm`.
+            # TODO: Automatically check for and delete stuck files so user doesn't have to
             CLIMessageDisplay.failure(
                 f"Cancelled upload for {display_alias}. It is possible that the server-"
                 + "side upload was created anyway. If you are unable to create a new"

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -33,6 +33,8 @@ from ghga_connector.core.uploading.uploader import Uploader
 
 log = logging.getLogger(__name__)
 
+USER_ABORT_EXCEPTIONS = (KeyboardInterrupt, asyncio.CancelledError)
+
 # The file state, as reported by the Upload API, that marks a cancelled (deleted)
 #  upload. A file in any other state is considered already present in the box.
 _CANCELLED_STATE = "cancelled"
@@ -183,9 +185,6 @@ def load_file_info_from_tsv(tsv_path: Path) -> list[CoreFileInfo]:
     return items
 
 
-_USER_ABORT_EXCEPTIONS = (KeyboardInterrupt, asyncio.CancelledError)
-
-
 def _signal_handler(signum, frame):
     """Capture KeyboardInterrupt"""
     CLIMessageDisplay.display("Cleanup in progress, please wait…")
@@ -317,7 +316,7 @@ async def upload_files_from_list(
         )
         try:
             await uploader.upload_file(encryptor=encryptor)
-        except _USER_ABORT_EXCEPTIONS:
+        except USER_ABORT_EXCEPTIONS:
             # User cancellation is handled here.
             CLIMessageDisplay.failure(
                 f"Upload aborted for {display_alias}, (file ID {file_id}), deleting."

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -15,6 +15,7 @@
 
 """Unit tests for upload_files_from_list in batch_processing"""
 
+import asyncio
 import signal
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -132,26 +133,32 @@ async def test_perform_cleanup_restores_sigint_handler(delete_raises):
     assert signal.getsignal(signal.SIGINT) is sentinel_handler
 
 
-async def test_upload_files_from_list_halts_on_keyboard_interrupt_during_init():
-    """Ctrl+C during initiate_file_upload() halts the batch cleanly: the current file and
-    all remaining files are reported as failed, and no traceback escapes.
+_ABORT_EXCEPTIONS = [KeyboardInterrupt(), asyncio.CancelledError()]
+
+
+@pytest.mark.parametrize("error", _ABORT_EXCEPTIONS)
+async def test_upload_files_from_list_halts_on_abort_during_init(error: BaseException):
+    """Test that keyboard cancel during initiate_file_upload() stops batch processing
+    and performs cleanup. The current and remaining files should be listed as failed.
     """
+    # Create a couple of test files to upload
     with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
         file_infos = [
             make_file_info_for_upload(path=Path(f1.name), alias="first"),
             make_file_info_for_upload(path=Path(f2.name), alias="second"),
         ]
+
+        # Rig a mock uploader to error during initiation
         aborting_uploader = AsyncMock()
-        aborting_uploader.initiate_file_upload.side_effect = KeyboardInterrupt()
+        aborting_uploader.initiate_file_upload.side_effect = error
         second_uploader = make_mock_uploader()
 
+        # Patch in the exploding mock uploader
         with (
             patch(
                 "ghga_connector.core.uploading.batch_processing.Uploader",
                 side_effect=[aborting_uploader, second_uploader],
             ),
-            patch("ghga_connector.core.uploading.batch_processing.Crypt4GHEncryptor"),
-            patch("ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"),
         ):
             result = await upload_files_from_list(
                 upload_client=AsyncMock(),
@@ -160,12 +167,52 @@ async def test_upload_files_from_list_halts_on_keyboard_interrupt_during_init():
                 max_concurrent_uploads=1,
             )
 
+        # Inspect the captured result and verify that `halted` is set to True
         assert result.halted
-        # Both the interrupted file and the un-attempted file are reported as failed.
+
+        # Make sure both files are reported as failed but no cleanup was done for the
+        #  second file because it was of course not started
         assert [fi.alias for fi in result.failed] == ["first", "second"]
-        # The second file must not be started, and no cleanup is attempted (no file_id).
         second_uploader.initiate_file_upload.assert_not_called()
         aborting_uploader.delete_file.assert_not_called()
+
+
+@pytest.mark.parametrize("abort", _ABORT_EXCEPTIONS)
+async def test_upload_files_from_list_halts_on_abort_during_upload(
+    abort: BaseException,
+):
+    """Test that keyboard cancel during upload_file() stops batch processing and
+    performs cleanup. The current and remaining files should be listed as failed.
+    """
+    # Set up two test files and the rigged-to-blow Mock Uploader
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="first"),
+            make_file_info_for_upload(path=Path(f2.name), alias="second"),
+        ]
+        aborting_uploader = make_mock_uploader(upload_raises=abort)
+        second_uploader = make_mock_uploader()
+
+        # Patch in the mock uploader, but also mock the encryptor since it gets called
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.Uploader",
+                side_effect=[aborting_uploader, second_uploader],
+            ),
+            patch("ghga_connector.core.uploading.batch_processing.Crypt4GHEncryptor"),
+        ):
+            result = await upload_files_from_list(
+                upload_client=AsyncMock(),
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+            )
+
+        # Inspect the results - make sure halted=True, and only first file cleaned up
+        assert result.halted
+        assert [fi.alias for fi in result.failed] == ["first", "second"]
+        aborting_uploader.delete_file.assert_called_once()
+        second_uploader.initiate_file_upload.assert_not_called()
 
 
 async def test_upload_process_stops_on_failure():

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -127,8 +127,7 @@ async def test_perform_cleanup_restores_sigint_handler(delete_raises):
     if delete_raises is not None:
         uploader.delete_file.side_effect = delete_raises
 
-    with patch("ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"):
-        await perform_cleanup(uploader=uploader, alias="some-file")
+    await perform_cleanup(uploader=uploader, alias="some-file")
 
     assert signal.getsignal(signal.SIGINT) is sentinel_handler
 

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -15,6 +15,7 @@
 
 """Unit tests for upload_files_from_list in batch_processing"""
 
+import signal
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from unittest.mock import AsyncMock, patch
@@ -30,6 +31,7 @@ from ghga_connector.core.uploading.batch_processing import (
     _MIN_ELISION_SAVINGS,
     BatchPassResult,
     _elide_middle,
+    perform_cleanup,
     run_batch_upload,
     upload_files_from_list,
 )
@@ -111,6 +113,59 @@ async def test_upload_files_from_list_deletes_on_errors(error: BaseException):
             )
 
         mock_uploader.delete_file.assert_called_once()
+
+
+@pytest.mark.parametrize("delete_raises", [None, RuntimeError("delete failed")])
+async def test_perform_cleanup_restores_sigint_handler(delete_raises):
+    """perform_cleanup must restore the previous SIGINT handler afterward, both on a
+    successful delete and when delete_file() raises, so Ctrl+C keeps working for the
+    rest of the batch.
+    """
+    sentinel_handler = signal.getsignal(signal.SIGINT)
+    uploader = AsyncMock()
+    if delete_raises is not None:
+        uploader.delete_file.side_effect = delete_raises
+
+    with patch("ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"):
+        await perform_cleanup(uploader=uploader, alias="some-file")
+
+    assert signal.getsignal(signal.SIGINT) is sentinel_handler
+
+
+async def test_upload_files_from_list_halts_on_keyboard_interrupt_during_init():
+    """Ctrl+C during initiate_file_upload() halts the batch cleanly: the current file and
+    all remaining files are reported as failed, and no traceback escapes.
+    """
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="first"),
+            make_file_info_for_upload(path=Path(f2.name), alias="second"),
+        ]
+        aborting_uploader = AsyncMock()
+        aborting_uploader.initiate_file_upload.side_effect = KeyboardInterrupt()
+        second_uploader = make_mock_uploader()
+
+        with (
+            patch(
+                "ghga_connector.core.uploading.batch_processing.Uploader",
+                side_effect=[aborting_uploader, second_uploader],
+            ),
+            patch("ghga_connector.core.uploading.batch_processing.Crypt4GHEncryptor"),
+            patch("ghga_connector.core.uploading.batch_processing.CLIMessageDisplay"),
+        ):
+            result = await upload_files_from_list(
+                upload_client=AsyncMock(),
+                file_info_list=file_infos,
+                my_private_key=SecretBytes(b"\x00" * 32),
+                max_concurrent_uploads=1,
+            )
+
+        assert result.halted
+        # Both the interrupted file and the un-attempted file are reported as failed.
+        assert [fi.alias for fi in result.failed] == ["first", "second"]
+        # The second file must not be started, and no cleanup is attempted (no file_id).
+        second_uploader.initiate_file_upload.assert_not_called()
+        aborting_uploader.delete_file.assert_not_called()
 
 
 async def test_upload_process_stops_on_failure():

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -135,8 +135,7 @@ async def test_perform_cleanup_restores_sigint_handler(delete_raises):
 _ABORT_EXCEPTIONS = [KeyboardInterrupt(), asyncio.CancelledError()]
 
 
-@pytest.mark.parametrize("error", _ABORT_EXCEPTIONS)
-async def test_upload_files_from_list_halts_on_abort_during_init(error: BaseException):
+async def test_upload_files_from_list_halts_on_abort_during_init():
     """Test that keyboard cancel during initiate_file_upload() stops batch processing
     and performs cleanup. The current and remaining files should be listed as failed.
     """
@@ -149,7 +148,7 @@ async def test_upload_files_from_list_halts_on_abort_during_init(error: BaseExce
 
         # Rig a mock uploader to error during initiation
         aborting_uploader = AsyncMock()
-        aborting_uploader.initiate_file_upload.side_effect = error
+        aborting_uploader.initiate_file_upload.side_effect = KeyboardInterrupt
         second_uploader = make_mock_uploader()
 
         # Patch in the exploding mock uploader

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -15,7 +15,6 @@
 
 """Unit tests for upload_files_from_list in batch_processing"""
 
-import asyncio
 import signal
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -30,6 +29,7 @@ from ghga_connector.constants import BATCH_RETRY_BACKOFF_SEC
 from ghga_connector.core.uploading.batch_processing import (
     _MAX_NAME_WIDTH,
     _MIN_ELISION_SAVINGS,
+    USER_ABORT_EXCEPTIONS,
     BatchPassResult,
     _elide_middle,
     perform_cleanup,
@@ -132,9 +132,6 @@ async def test_perform_cleanup_restores_sigint_handler(delete_raises):
     assert signal.getsignal(signal.SIGINT) is sentinel_handler
 
 
-_ABORT_EXCEPTIONS = [KeyboardInterrupt(), asyncio.CancelledError()]
-
-
 async def test_upload_files_from_list_halts_on_abort_during_init():
     """Test that keyboard cancel during initiate_file_upload() stops batch processing
     and performs cleanup. The current and remaining files should be listed as failed.
@@ -175,7 +172,7 @@ async def test_upload_files_from_list_halts_on_abort_during_init():
         aborting_uploader.delete_file.assert_not_called()
 
 
-@pytest.mark.parametrize("abort", _ABORT_EXCEPTIONS)
+@pytest.mark.parametrize("abort", USER_ABORT_EXCEPTIONS)
 async def test_upload_files_from_list_halts_on_abort_during_upload(
     abort: BaseException,
 ):


### PR DESCRIPTION
During upload we found that you couldn't cancel operations reliably. You could hit CTRL+C and the upload would just carry on. It turns out that this was due to a bug in the SIGINT handling. We'd previously made it so that you couldn't accidentally do an extra keyboard cancel during cleanup, but then we forgot to set this back. This meant that things like a pre-existing file preventing init or a network error would trigger the cleanup and then block SIGINT for the rest of the run. This makes sure to set it back and also adds a wrapper to the outermost call layer (in `cli.py`) to catch/gracefully log any uncaught KeyboardInterrupts.