### PR TITLE
Don't skip failed files (GSI-2473)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_connector"
-version = "3.0.0"
+version = "3.0.1"
 description = "GHGA Connector - A CLI client application for interacting with the GHGA system."
 dependencies = [
     "typer~=0.19",

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ We recommend using the provided Docker container.
 
 A pre-built version is available on [Docker Hub](https://hub.docker.com/repository/docker/ghga/ghga-connector):
 ```bash
-docker pull ghga/ghga-connector:3.0.0
+docker pull ghga/ghga-connector:3.0.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/ghga-connector:3.0.0 .
+docker build -t ghga/ghga-connector:3.0.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes.
@@ -40,7 +40,7 @@ However for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is pre-configured:
-docker run -p 8080:8080 ghga/ghga-connector:3.0.0 --help
+docker run -p 8080:8080 ghga/ghga-connector:3.0.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_connector"
-version = "3.0.0"
+version = "3.0.1"
 description = "GHGA Connector - A CLI client application for interacting with the GHGA system."
 dependencies = [
     "typer~=0.19",

--- a/src/ghga_connector/core/uploading/batch_processing.py
+++ b/src/ghga_connector/core/uploading/batch_processing.py
@@ -38,6 +38,7 @@ USER_ABORT_EXCEPTIONS = (KeyboardInterrupt, asyncio.CancelledError)
 # The file state, as reported by the Upload API, that marks a cancelled (deleted)
 #  upload. A file in any other state is considered already present in the box.
 _CANCELLED_STATE = "cancelled"
+_FAILED_STATE = "failed"
 
 # When listing skipped or failed aliases in a message, show at most this many before
 #  eliding the rest, so a large resume doesn't print a wall of text.
@@ -351,7 +352,7 @@ async def _already_uploaded_aliases(upload_client: UploadClient) -> set[str]:
     return {
         upload.alias
         for upload in uploads
-        if (upload.state or "").lower() != _CANCELLED_STATE
+        if (upload.state or "").lower() not in {_CANCELLED_STATE, _FAILED_STATE}
     }
 
 

--- a/tests/unit/test_batch_processing.py
+++ b/tests/unit/test_batch_processing.py
@@ -450,18 +450,24 @@ async def test_run_batch_upload_skips_already_uploaded():
         assert captured == [["fresh"]]
 
 
-async def test_run_batch_upload_does_not_skip_cancelled():
-    """A cancelled (deleted) alias in the box is re-uploaded, not skipped."""
-    with NamedTemporaryFile() as f:
-        file_infos = [make_file_info_for_upload(path=Path(f.name), alias="redo")]
+async def test_run_batch_upload_does_not_skip_cancelled_or_failed():
+    """Cancelled and failed aliases in the box are re-uploaded, not skipped."""
+    with NamedTemporaryFile() as f1, NamedTemporaryFile() as f2:
+        file_infos = [
+            make_file_info_for_upload(path=Path(f1.name), alias="cancelled-file"),
+            make_file_info_for_upload(path=Path(f2.name), alias="failed-file"),
+        ]
         upload_client = _make_upload_client(
-            [UploadedFileInfo(id=uuid4(), alias="redo", state="cancelled")]
+            [
+                UploadedFileInfo(id=uuid4(), alias="cancelled-file", state="cancelled"),
+                UploadedFileInfo(id=uuid4(), alias="failed-file", state="failed"),
+            ]
         )
 
         captured: list[list[str]] = []
 
         async def fake_batch_cycle(*, file_info_list, **_kwargs):
-            captured.append([fi.alias for fi in file_info_list])
+            captured.extend([fi.alias for fi in file_info_list])
             return BatchPassResult(failed=[], halted=False)
 
         with patch(
@@ -476,7 +482,7 @@ async def test_run_batch_upload_does_not_skip_cancelled():
                 max_retries=0,
             )
 
-        assert captured == [["redo"]]
+        assert captured == ["cancelled-file", "failed-file"]
 
 
 async def test_run_batch_upload_all_skipped_does_not_upload():


### PR DESCRIPTION
This PR addresses a bug in batch processing that caused previously failed files to be skipped in batch upload instead of being retried.